### PR TITLE
Use UMD for browser target

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -64,7 +64,7 @@ switch (PLATFORM) {
         bundleSuffix = (CONFIG === "debug") ? "" : ".min";
         defines.PLATFORM_BROWSER = true;
         target = "web";
-        libraryTarget = "var";
+        libraryTarget = "umd";
         break;
 
     default:


### PR DESCRIPTION
Hi :wave: I was having trouble setting up Lightstep in the browser. We're using webpack as well to require dependencies. When I load the webpage `Lightstep` is an empty object after I require it.

![screen shot 2016-03-15 at 4 04 10 pm](https://cloud.githubusercontent.com/assets/1173886/13794026/df6270d6-eac7-11e5-8be9-f332fc27c3b5.png)

I was wondering if there was a reason for compiling the libraryTarget to `var`? Setting the libraryTarget is set to `umd` seems to fix the problem. I also checked the example and it seemed to work too.