### PR TITLE
Use performance on window object

### DIFF
--- a/src/imp/platform/browser/platform_browser.js
+++ b/src/imp/platform/browser/platform_browser.js
@@ -7,10 +7,10 @@ const kCookieTimeToLiveSeconds = 7 * 24 * 60 * 60;
 
 let nowMicrosImp = (function() {
     // Is a hi-res timer available?
-    if (performance &&
-        performance.now &&
-        performance.timing &&
-        performance.timing.navigationStart) {
+    if (window.performance &&
+        window.performance.now &&
+        window.performance.timing &&
+        window.performance.timing.navigationStart) {
 
         var start = performance.timing.navigationStart;
         return function() {


### PR DESCRIPTION
I am seeing an exception `ReferenceError: Can't find variable: performance` in our CI tests. Everything works fine for us except in the CI environment. I suppose some headless browsers might not implement the Web Performance API? Anyways, accessing performance from `window` fixes it for us.