### PR TITLE
Add xhr_inclusion_patterns option and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/*
 tmp-publish
 npm-debug.log
+npm-debug.log.*

--- a/README.md
+++ b/README.md
@@ -28,6 +28,26 @@ Tracer.initGlobalTracer(LightStep.tracer({
 
 * **Node**: Node versions >= 0.12 are supported.
 
+## LightStep Initialization Options
+
+### Browser-specific
+
+#### `xhr_url_inclusion_patterns RegExp[]`
+
+The LightStep browser library automatically instruments all XMLHttpRequests (i.e. AJAX requests). This array allows an inclusion list to be specified: only URLs that match one or more of the regular expressions in this list will be considered for auto-instrumentation.
+
+The default value is a single regular expression wildcard matching all strings.
+
+For a given URL to be auto-instrumented, it must match at least one regular expression in `xhr_url_inclusion_patterns` and not match any regular expressions in `xhr_url_exclusion_patterns`.
+
+#### `xhr_url_exclusion_patterns RegExp[]`
+
+The LightStep browser library automatically instruments all XMLHttpRequests (i.e. AJAX requests). This array allows an exclusion list to be specified: a URL matching any of the exclusion patterns will not be instrumented.
+
+The default value is an empty array.
+
+For a given URL to be auto-instrumented, it must match at least one regular expression in `xhr_url_inclusion_patterns` and not match any regular expressions in `xhr_url_exclusion_patterns`.
+
 ## License
 
 [The MIT License](LICENSE).


### PR DESCRIPTION
## Summary

* Adds a `xhr_url_inclusion_patterns` array option to whitelist what XHRs get auto-instrumented
* Adds basic docs for the XHR options
* Add a visible warning in the console if the `xhr_*` options are passed the wrong type

FYI, @luk3thomas. Add a comment to the PR if this does not address your needs!