### PR TITLE
Add LightStep trace URL API, add URL to examples, add further README details

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ LightStep implementation of the [OpenTracing API](http://opentracing.io/).
 npm install --save lightstep-tracer opentracing
 ```
 
+All modern browsers and Node versions >= 0.12 are supported.
+
 ## Getting Started
 
 To use LightStep as the OpenTracing binding, initialize the global tracer with the LightStep implementation:
@@ -24,29 +26,39 @@ Tracer.initGlobalTracer(LightStep.tracer({
 * See [examples/node](https://github.com/lightstep/lightstep-tracer-javascript/tree/master/examples/node) for a Node.js server-side example
 
 
-## Supported Platforms
+## LightStep Specific API
 
-* **Node**: Node versions >= 0.12 are supported.
+### LightStep
 
-## LightStep Initialization Options
+---
 
-### Browser-specific
+### tracer(options)
 
-#### `xhr_url_inclusion_patterns RegExp[]`
+* `access_token` `string` *required* - the project access token
+* `group_name` `string` *required* - the string identifier for the application, service, or process. (*NOTE:* this parameter is subject to renaming for consistency with other LightStep / OpenTracing libraries and maybe be optional in the future.)
 
-The LightStep browser library automatically instruments all XMLHttpRequests (i.e. AJAX requests). This array allows an inclusion list to be specified: only URLs that match one or more of the regular expressions in this list will be considered for auto-instrumentation.
+**Browser-specific initialization options**
 
-The default value is a single regular expression wildcard matching all strings.
+* `xhr_url_inclusion_patterns` `RegExp[]` - an array of regular expressions used to whitelist URLs for `XMLHttpRequest` auto-instrumentation. The default value is wildcard matching all strings. For a given URL to be instrumented, it must match at least one regular expression in `xhr_url_inclusion_patterns` and not match any regular expressions in `xhr_url_exclusion_patterns`.
 
-For a given URL to be auto-instrumented, it must match at least one regular expression in `xhr_url_inclusion_patterns` and not match any regular expressions in `xhr_url_exclusion_patterns`.
+* `xhr_url_exclusion_patterns` `RegExp[]` - an array of regular expressions used to exclude URLs from `XMLHttpRequest` auto-instrumentation. The default value is an empty array. For a given URL to be instrumented, it must match at least one regular expression in `xhr_url_inclusion_patterns` and not match any regular expressions in `xhr_url_exclusion_patterns`.
 
-#### `xhr_url_exclusion_patterns RegExp[]`
+### SpanImp
 
-The LightStep browser library automatically instruments all XMLHttpRequests (i.e. AJAX requests). This array allows an exclusion list to be specified: a URL matching any of the exclusion patterns will not be instrumented.
+---
 
-The default value is an empty array.
+### generateTraceURL()
 
-For a given URL to be auto-instrumented, it must match at least one regular expression in `xhr_url_inclusion_patterns` and not match any regular expressions in `xhr_url_exclusion_patterns`.
+Returns an absolute URL to the LightStep application for the trace containing this span. It is safe to call this method after `finish()`.
+
+```js
+...
+span.finish();
+
+var url = span.imp().generateTraceURL())
+console.log('View the trace for this span at:', url);
+```
+
 
 ## License
 

--- a/examples/browser/browser.html
+++ b/examples/browser/browser.html
@@ -25,6 +25,9 @@
             <button id="span-button">Get GitHub info</button>
 
             <h3>Results</h3>
+            <div id="trace-link-div" style="opacity : 0">
+                <a id="trace-link" href="" target="_blank">Link to trace on LightStep</a>
+            </div>
             <textarea id='results'></textarea>
         </div>
 
@@ -57,6 +60,8 @@
         var username = document.getElementById('username');
         var button = document.getElementById('span-button');
         var results = document.getElementById('results');
+        var linkDiv = document.getElementById('trace-link-div');
+        var link = document.getElementById('trace-link');
 
         button.onclick = function() {
             printUserInfo(username.value);
@@ -93,6 +98,13 @@
                         span.logEvent('error', err);
                     }
                     span.finish();
+
+                    // Generate a LightStep-specific URL
+                    // Note the call to imp() to access the LightStep implementation
+                    // object.
+                    var url = span.imp().generateTraceURL();
+                    link.href = url;
+                    linkDiv.style.opacity = 1.0;
                 });
             });
         }

--- a/examples/node/index.js
+++ b/examples/node/index.js
@@ -69,6 +69,13 @@ function printUserInfo(username) {
                 json  : json,
             })
             span.finish();
+
+            // Generate a LightStep-specific URL
+            // Note the call to imp() to access the LightStep implementation
+            // object.
+            var url = span.imp().generateTraceURL();
+            console.log('');
+            console.log('View the trace at: ' + url);
         });
     });
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -19,3 +19,5 @@ export const LOG_STRING_TO_LEVEL = {
 
 // The report interval for empty reports used to sample the clock skew
 export const CLOCK_STATE_REFRESH_INTERVAL_MS = 350;
+
+export const LIGHTSTEP_APP_URL_PREFIX = 'https://app.lightstep.com';

--- a/src/imp/span_imp.js
+++ b/src/imp/span_imp.js
@@ -119,6 +119,27 @@ export default class SpanImp {
         this._tags['parent_span_guid'] = coerce.toString(guid);
     }
 
+    /**
+     * Returns a URL to the trace containing this span.
+     *
+     * Unlike most methods, it *is* safe to call this method after `finish()`.
+     *
+     * @return {string} the absolute URL for the span
+     */
+    generateTraceURL() {
+        let micros;
+        if (this._beginMicros > 0 && this._endMicros > 0) {
+            micros = Math.floor((this._beginMicros + this._endMicros) / 2);
+        } else {
+            micros = tracer._platform.nowMicros();
+        }
+
+        let urlPrefix = constants.LIGHTSTEP_APP_URL_PREFIX;
+        let accessToken = this._tracer.options()['access_token'];
+        let guid = this.guid();
+        return `${urlPrefix}/${accessToken}/trace?span_guid=${guid}&at_micros=${micros}`;
+    }
+
     getTags() {
         return this._tags;
     }


### PR DESCRIPTION
* Adds URL links to the traces for the spans generated by the code in the `examples` directory
* Adds a bit more info to the README