### PR TITLE
Update to consistent naming

### DIFF
--- a/src/imp/platform/browser/options_parser.js
+++ b/src/imp/platform/browser/options_parser.js
@@ -54,29 +54,13 @@ module.exports.parseScriptElementOptions = function (opts, browserOpts) {
     if (typeof groupName === "string" && groupName.length > 0) {
         opts.group_name = groupName;
     }
-    let serviceHost = dataset.service_host;
-    if (typeof serviceHost === "string" && serviceHost.length > 0) {
-        opts.service_host = serviceHost;
+    let collectorHost = dataset.collector_host;
+    if (typeof collectorHost === "string" && collectorHost.length > 0) {
+        opts.collector_host = collectorHost;
     }
-    let servicePort = dataset.service_port;
-    if (servicePort) {
-        opts.service_port = parseInt(servicePort);
-    }
-    let joinIds = dataset.join_ids;
-    if (joinIds) {
-        try {
-            opts.join_ids = JSON.parse(joinIds);
-        } catch (e) {
-            console.error("Could not parse join_ids string:", joinIds);
-        }
-    }
-
-    // Special case the "end_user_id" since that is by far the most likely
-    // join ID to be set globally by browser instrumentation
-    var endUserId = dataset.end_user_id;
-    if (endUserId) {
-        opts.join_ids = opts.join_ids || {};
-        opts.join_ids.end_user_id = endUserId;
+    let collectorPort = dataset.collector_port;
+    if (collectorPort) {
+        opts.collector_port = parseInt(collectorPort);
     }
 
     let enable = dataset.enable;
@@ -91,9 +75,9 @@ module.exports.parseScriptElementOptions = function (opts, browserOpts) {
     if (typeof debug == "string" && debug == "true") {
         opts.debug = true;
     }
-    let verbosity = dataset.verbosity;
-    if (typeof verbosity === "string") {
-        opts.verbosity = parseInt(verbosity);
+    let verbose = dataset.verbose;
+    if (typeof verbose === "string") {
+        opts.verbose = parseInt(verbose);
     }
 
     let init = dataset.init_global_tracer;
@@ -122,9 +106,9 @@ module.exports.parseURLQueryOptions = function(opts) {
     if (params.lightstep_debug) {
         opts.debug = true;
     }
-    if (params.lightstep_verbosity) {
+    if (params.lightstep_verbose) {
         try {
-            opts.verbosity = parseInt(params.lightstep_verbosity);
+            opts.verbose = parseInt(params.lightstep_verbose);
         } catch (_ignored) {}
     }
     if (params.lightstep_log_to_console) {

--- a/src/imp/platform/browser/platform_browser.js
+++ b/src/imp/platform/browser/platform_browser.js
@@ -111,9 +111,9 @@ class PlatformBrowser {
         Tracer.initGlobalTracer(lib.tracer(opts));
     }
 
-    runtimeAttributes() {
+    tracerTags() {
         return {
-            cruntime_platform : 'browser',
+            lightstep_tracer_platform : 'browser',
         };
     }
 

--- a/src/imp/platform/browser/transport_browser.js
+++ b/src/imp/platform/browser/transport_browser.js
@@ -17,9 +17,9 @@ export default class TransportBrowser {
             return;
         }
 
-        let host = opts.service_host;
-        let port = opts.service_port;
-        let scheme = opts.secure ? "https" : "http";
+        let host = opts.collector_host;
+        let port = opts.collector_port;
+        let scheme = opts.collector_encryption !== 'none' ? 'https' : 'http';
         this._hostport = `${scheme}://${host}:${port}`;
 
         // Currently the only support Thrift browser protocol is JSON.

--- a/src/imp/platform/node/platform_node.js
+++ b/src/imp/platform/node/platform_node.js
@@ -1,4 +1,4 @@
-
+const os = require('os');
 
 let startTimeMicros = computeStartMicros();
 
@@ -26,10 +26,10 @@ export default class PlatformNode {
         }
 
         let packageObject = require('../../../../package.json');
-        let requiredVersionString = packageObject.engines["node"];
+        let requiredVersionString = packageObject.engines['node'];
         let requiredMatch = /^>=(\d+)\.(\d+)\.(\d+)$/.exec(requiredVersionString);
         if (!requiredMatch || requiredMatch.length !== 4) {
-            throw new Error("Internal error: package.json node requirement malformed");
+            throw new Error('Internal error: package.json node requirement malformed');
         }
 
         let err = `Fatal Error: insufficient node version. Requires node ${requiredVersionString}`;
@@ -62,7 +62,7 @@ export default class PlatformNode {
     }
 
     name() {
-        return "node";
+        return 'node';
     }
 
     static initLibrary(lib) {
@@ -79,7 +79,7 @@ export default class PlatformNode {
     }
 
     generateUUID() {
-        return require("crypto").randomBytes(8).toString('hex');
+        return require('crypto').randomBytes(8).toString('hex');
     }
 
     onBeforeExit(...args) {
@@ -98,22 +98,22 @@ export default class PlatformNode {
         let opts = {};
         for (let value of process.argv) {
             switch (value.toLowerCase()) {
-            case "--lightstep-log_to_console":
-            case "--lightstep-log_to_console=true":
-            case "--lightstep-log_to_console=1":
+            case '--lightstep-log_to_console':
+            case '--lightstep-log_to_console=true':
+            case '--lightstep-log_to_console=1':
                 opts.log_to_console = true;
                 break;
 
-            case "--lightstep-debug":
-            case "--lightstep-debug=true":
-            case "--lightstep-debug=1":
+            case '--lightstep-debug':
+            case '--lightstep-debug=true':
+            case '--lightstep-debug=1':
                 opts.debug = true;
                 break;
 
-            case "--lightstep-verbosity=2":
+            case '--lightstep-verbose=2':
                 opts.verbosity = 2;
                 break;
-            case "--lightstep-verbosity=1":
+            case '--lightstep-verbose=1':
                 opts.verbosity = 1;
                 break;
             }
@@ -121,13 +121,22 @@ export default class PlatformNode {
         return opts;
     }
 
-    runtimeAttributes() {
-        return {
-            cruntime_platform : "node",
+    tracerTags() {
+        let tags = {
+            lightstep_tracer_platform : 'node',
             node_version      : process.version,
             node_platform     : process.platform,
             node_arch         : process.arch,
+            hostname          : os.hostname(),
         };
+        if (process.argv) {
+            tags.command_line = process.argv.join(' ');
+        }
+        if (process.execArgv) {
+            tags.node_arguments = process.execArgv.join(' ');
+        }
+
+        return tags;
     }
 
     fatal(message) {

--- a/src/imp/platform/node/transport_node.js
+++ b/src/imp/platform/node/transport_node.js
@@ -19,7 +19,7 @@ export default class TransportNode {
             transport   : thrift.TBufferedTransport,
             protocol    : thrift.TBinaryProtocol,
             path        : "/_rpc/v1/reports/binary",
-            https       : opts.secure,
+            https       : (opts.collector_encryption !== 'none'),
             nodeOptions : {},
         };
         if (!opts.certificate_verification) {
@@ -28,7 +28,7 @@ export default class TransportNode {
             thriftOptions.nodeOptions.strictSSL = false;
         }
 
-        this._connection = thrift.createHttpConnection(opts.service_host, opts.service_port, thriftOptions);
+        this._connection = thrift.createHttpConnection(opts.collector_host, opts.collector_port, thriftOptions);
         this._client = thrift.createHttpClient(crouton_thrift.ReportingServiceClient, this._connection);
     }
 

--- a/src/imp/tracer_imp.js
+++ b/src/imp/tracer_imp.js
@@ -56,6 +56,8 @@ export default class TracerImp extends EventEmitter {
 
         // Debugging options
         //
+        // These are not part of the supported public API.
+        //
         // If false, SSL certificate verification is skipped. Useful for testing.
         this.addOption('certificate_verification',      { type: 'bool',    defaultValue: true });
         // If true, internal logs will be included in the reports
@@ -67,6 +69,7 @@ export default class TracerImp extends EventEmitter {
 
         // Unit testing options
         this.addOption('override_transport',    { type : 'any',    defaultValue: null });
+        this.addOption('silent',                { type : 'bool',   defaultValue: false });
 
         // Hard upper limits to protect against worst-case scenarios
         this.addOption('log_message_length_hard_limit', { type: 'int',     defaultValue: 512 * 1024 });
@@ -1056,7 +1059,9 @@ export default class TracerImp extends EventEmitter {
             } catch (e) {
                 msg = "[FORMAT ERROR]: " + fmt;
             }
-            console.warn(msg);
+            if (!this._options.silent) {
+                console.warn(msg);
+            }
         }
         this._internalLog("[LightStep:I] ", constants.LOG_INFO, fmt, ...args);
     }

--- a/src/imp/tracer_imp.js
+++ b/src/imp/tracer_imp.js
@@ -22,33 +22,37 @@ const packageObject = require('../../package.json');
 const CARRIER_TRACER_STATE_PREFIX = 'ot-tracer-';
 const CARRIER_BAGGAGE_PREFIX = 'ot-baggage-';
 
-const DEFAULT_SERVICE_PORT_SECURE   = 443;
-const DEFAULT_SERVICE_PORT_INSECURE = 80;
+const DEFAULT_COLLECTOR_HOSTNAME   = 'collector.lightstep.com';
+const DEFAULT_COLLECTOR_PORT_TLS   = 443;
+const DEFAULT_COLLECTOR_PORT_PLAIN = 80;
 
 export default class TracerImp extends EventEmitter {
 
     constructor(opts) {
         super();
+        opts = opts || {};
 
         // Platform abstraction layer
         this._platform = new Platform(this);
-        this._runtimeGUID = this.override_runtime_guid || null;  // Set once the group name is set
+        this._runtimeGUID = opts.guid || this.override_runtime_guid || null;  // Set once the group name is set
         this._pluginNames = {};
         this._options = {};
         this._optionDescs = [];
 
         // Core options
-        //
-        this.addOption('access_token',                  { type: 'string',  defaultValue: '' });
-        this.addOption('group_name',                    { type: 'string',  defaultValue: '' });
-        this.addOption('disabled',                      { type: 'bool',    defaultValue: false });
-        this.addOption('service_host',                  { type: 'string',  defaultValue: 'collector.lightstep.com' });
-        this.addOption('service_port',                  { type: 'int',     defaultValue: DEFAULT_SERVICE_PORT_SECURE });
-        this.addOption('secure',                        { type: 'bool',    defaultValue: true });
-        this.addOption('report_period_millis',          { type: 'int',     defaultValue: 2500 });
-        this.addOption('max_log_records',               { type: 'int',     defaultValue: 4096 });
-        this.addOption('max_span_records',              { type: 'int',     defaultValue: 4096 });
-        this.addOption('join_ids',                      { type: 'any',     defaultValue: {} });
+        this.addOption('access_token',          { type: 'string',  defaultValue: '' });
+        this.addOption('group_name',            { type: 'string',  defaultValue: '' });
+        this.addOption('collector_host',        { type: 'string',  defaultValue: DEFAULT_COLLECTOR_HOSTNAME });
+        this.addOption('collector_port',        { type: 'int',     defaultValue: DEFAULT_COLLECTOR_PORT_TLS });
+        this.addOption('collector_encryption',  { type: 'string',  defaultValue: 'tls' });
+        this.addOption('tags',                  { type: 'any',     defaultValue: {} });
+        this.addOption('max_reporting_interval_millis',  { type: 'int',     defaultValue: 2500 });
+
+        // Non-standard, may be deprecated
+        this.addOption('disabled',              { type: 'bool',    defaultValue: false });
+        this.addOption('max_log_records',       { type: 'int',     defaultValue: 4096 });
+        this.addOption('max_span_records',      { type: 'int',     defaultValue: 4096 });
+        this.addOption('join_ids',              { type: 'any',     defaultValue: {} });
 
         // Debugging options
         //
@@ -59,10 +63,10 @@ export default class TracerImp extends EventEmitter {
         // I.e. report only on explicit calls to flush()
         this.addOption('disable_reporting_loop',        { type: 'bool',    defaultValue: false });
         // Log verbosity level
-        this.addOption('verbosity',                     { type: 'int', min: 0, max: 2, defaultValue: 0 });
+        this.addOption('verbose',               { type : 'int', min: 0, max: 9, defaultValue: 0 });
 
         // Unit testing options
-        this.addOption('override_transport',            { type : 'any',    defaultValue: null });
+        this.addOption('override_transport',    { type : 'any',    defaultValue: null });
 
         // Hard upper limits to protect against worst-case scenarios
         this.addOption('log_message_length_hard_limit', { type: 'int',     defaultValue: 512 * 1024 });
@@ -92,11 +96,11 @@ export default class TracerImp extends EventEmitter {
         this._clockState = new ClockState({
             nowMicros : () => this._platform.nowMicros(),
             localStoreGet : () => {
-                let key = `clock_state/${this._options.service_host}`;
+                let key = `clock_state/${this._options.collector_host}`;
                 return this._platform.localStoreGet(key);
             },
             localStoreSet : (value) => {
-                let key = `clock_state/${this._options.service_host}`;
+                let key = `clock_state/${this._options.collector_host}`;
                 return this._platform.localStoreSet(key, value);
             },
         })
@@ -315,11 +319,11 @@ export default class TracerImp extends EventEmitter {
             throw new UserException('options() must be called with an object: type was ' + typeof opts);
         }
 
-        // 'secure' is an alias for the common cases of 'service_port'
-        if (opts.secure !== undefined && opts.service_port === undefined) {
-            opts.service_port = opts.secure ?
-                DEFAULT_SERVICE_PORT_SECURE :
-                DEFAULT_SERVICE_PORT_INSECURE;
+        // "collector_encryption" acts an alias for the common cases of 'collector_port'
+        if (opts.collector_encryption !== undefined && opts.collector_port === undefined) {
+            opts.collector_port = opts.collector_encryption !== 'none' ?
+                DEFAULT_COLLECTOR_PORT_TLS :
+                DEFAULT_COLLECTOR_PORT_PLAIN;
         }
 
         // Track what options have been modified
@@ -444,29 +448,29 @@ export default class TracerImp extends EventEmitter {
         if (this._thriftAuth !== null) {
 
             if (!this._thriftRuntime) {
-                return this._internalErrorf("Inconsistent state: thrift auth initialized without runtime.")
+                return this._internalErrorf('Inconsistent state: thrift auth initialized without runtime.')
             }
             if (modified.access_token) {
-                throw new UserException("Cannot change access_token after it has been set.");
+                throw new UserException('Cannot change access_token after it has been set.');
             }
             if (modified.group_name) {
-                throw new UserException("Cannot change group_name after it has been set.");
+                throw new UserException('Cannot change group_name after it has been set.');
             }
-            if (modified.service_host) {
-                throw new UserException("Cannot change service_host after the connection is established");
+            if (modified.collector_host) {
+                throw new UserException('Cannot change collector_host after the connection is established');
             }
-            if (modified.service_port) {
-                throw new UserException("Cannot change service_host after the connection is established");
+            if (modified.collector_port) {
+                throw new UserException('Cannot change collector_port after the connection is established');
             }
-            if (modified.secure) {
-                throw new UserException("Cannot change service_host after the connection is established");
+            if (modified.collector_encryption) {
+                throw new UserException('Cannot change collector_encryption after the connection is established');
             }
             return;
         }
 
         // See if the Thrift data can be initialized
         if (this._options.access_token.length > 0 && this._options.group_name.length > 0) {
-            this._internalInfofV2("Initializing thrift reporting data");
+            this._internalInfofV2('Initializing thrift reporting data');
 
             this._runtimeGUID = this._platform.runtimeGUID(this._options.group_name);
 
@@ -474,20 +478,30 @@ export default class TracerImp extends EventEmitter {
                 access_token : this._options.access_token,
             });
 
-            let attrs = {
-                cruntime_name    : packageObject.name,
-                cruntime_version : packageObject.version,
-            };
-            let platformAttrs = this._platform.runtimeAttributes();
-            for (let key in platformAttrs) {
-                attrs[key] = platformAttrs[key];
+            //
+            // Assemble the tracer tags from the user-specified and automatic,
+            // internal tags.
+            //
+            let tags = {};
+            for (let key in this._options.tags) {
+                let value = this._options.tags[key];
+                if (typeof value !== 'string') {
+                    this._visibleWarnfOnce('Tracer tag value is not a string: key=%s', key);
+                    continue;
+                }
+                tags[key] = value;
+            }
+            tags.lightstep_tracer_version = packageObject.version;
+            let platformTags = this._platform.tracerTags();
+            for (let key in platformTags) {
+                tags[key] = platformTags[key];
             }
 
             let thriftAttrs = [];
-            for (let key in attrs) {
+            for (let key in tags) {
                 thriftAttrs.push(new crouton_thrift.KeyValue({
                     Key   : coerce.toString(key),
-                    Value : coerce.toString(attrs[key]),
+                    Value : coerce.toString(tags[key]),
                 }));
             }
             this._thriftRuntime = new crouton_thrift.Runtime({
@@ -845,15 +859,15 @@ export default class TracerImp extends EventEmitter {
 
         // If the clock state is still being primed, potentially use the
         // shorted report interval
-        let reportPeriod = this._options.report_period_millis;
+        let reportInterval = this._options.max_reporting_interval_millis;
         if (!this._clockState.isReady()) {
-            reportPeriod = Math.min(constants.CLOCK_STATE_REFRESH_INTERVAL_MS, reportPeriod);
+            reportInterval = Math.min(constants.CLOCK_STATE_REFRESH_INTERVAL_MS, reportInterval);
         }
 
         // After 3 consecutive errors, expand the retry delay up to 8x the
         // normal interval. Also, jitter the delay by +/- 10%
         let backOff = 1 + Math.min(7, Math.max(0, this._reportErrorStreak - 3));
-        let basis = backOff * reportPeriod;
+        let basis = backOff * reportInterval;
         let jitter = 1.0 + (Math.random() * 0.2 - 0.1);
         let delay = Math.floor(Math.max(0, jitter * basis));
 

--- a/src/plugins/instrument_document_load.js
+++ b/src/plugins/instrument_document_load.js
@@ -125,8 +125,6 @@ class InstrumentPageLoad {
                 continue;
             }
 
-
-
             let micros = value * 1000.0;
             let payload = undefined;
 

--- a/src/plugins/instrument_xhr.js
+++ b/src/plugins/instrument_xhr.js
@@ -65,7 +65,7 @@ class InstrumentXHR {
     _handleOptions(modified, current) {
         // Automatically add the service host itself to the list of exclusions
         // to avoid reporting on the reports themselves
-        let serviceHost = modified.service_host;
+        let serviceHost = modified.collector_host;
         if (serviceHost) {
             this._addServiceHostToExclusions(current);
         }
@@ -85,7 +85,7 @@ class InstrumentXHR {
      * as that recursive instrumentation is more confusing than valuable!
      */
     _addServiceHostToExclusions(opts) {
-        if (opts.service_host.length === 0) {
+        if (opts.collector_host.length === 0) {
             return;
         }
 
@@ -96,8 +96,8 @@ class InstrumentXHR {
 
         // Check against the hostname without the port as well as the canonicalized
         // URL may drop the standard port.
-        let host = escapeRegExp(opts.service_host);
-        let port = escapeRegExp(opts.service_port);
+        let host = escapeRegExp(opts.collector_host);
+        let port = escapeRegExp(opts.collector_port);
         let set = [ new RegExp('^https?://' + host + ':' + port) ];
         if (port == "80") {
             set.push(new RegExp('^http://' + host));

--- a/test/suites/common/options.js
+++ b/test/suites/common/options.js
@@ -78,6 +78,7 @@ describe('options()', function() {
                 access_token : '{your_access_token}',
                 group_name   : '{node_test_suite}',
                 disable_reporting_loop : true,
+                silent       : true,
                 tags         : testTable[i][0],
             });
             var actual = {};

--- a/test/suites/common/options.js
+++ b/test/suites/common/options.js
@@ -1,6 +1,6 @@
-describe("options()", function() {
+describe('options()', function() {
 
-    it("should throw a UserError on invalid options", function() {
+    it('should throw a UserError on invalid options', function() {
 
         expect(function () {
             Tracer.imp().options({ });
@@ -12,36 +12,83 @@ describe("options()", function() {
 
         expect(function () {
             Tracer.imp().options({
-                invalid_option_name    : "test",
-                another_invalid_option : "test",
+                invalid_option_name    : 'test',
+                another_invalid_option : 'test',
             });
         }).to.throw();
     });
 
-    it("should allow the group_name and access_token to be set only once", function() {
+    it('should allow the group_name and access_token to be set only once', function() {
 
         expect(function () {
             var rt = LightStep.createRuntime();
             rt.options({
-                group_name   : "my_group",
-                access_token : "1",
+                group_name   : 'my_group',
+                access_token : '1',
                 disable_reporting_loop : true,
             });
             rt.options({
-                group_name  : "your_group",
+                group_name  : 'your_group',
             });
         }).to.throw();
 
         expect(function () {
             var rt = LightStep.createRuntime();
             rt.options({
-                group_name   : "my_group",
-                access_token : "1",
+                group_name   : 'my_group',
+                access_token : '1',
                 disable_reporting_loop : true,
             });
             rt.options({
-                access_token : "2",
+                access_token : '2',
             });
         }).to.throw();
+    });
+
+    it('should allow user-specified tracer tags', function() {
+        var testTable = [
+            [
+                {},
+                {},
+            ],
+            [
+                { 'my_tag' : 'strings_are_ok' },
+                { 'my_tag' : 'strings_are_ok' },
+            ],
+            [
+                { 'my_tag' : 'strings_are_ok', 'second_tag' : 'dolphins' },
+                { 'my_tag' : 'strings_are_ok', 'second_tag' : 'dolphins' },
+            ],
+            [
+                { 'my_tag' : 1233 },
+                { 'my_tag' : undefined },
+            ],
+            [
+                { 'my_array' : [ 1, 2, 3] },
+                {},
+            ],
+            [
+                { 'my_null' : null },
+                {},
+            ],
+        ];
+
+        for (var i = 0; i < testTable.length; i++) {
+            var tracer = LightStep.tracer({
+                access_token : '{your_access_token}',
+                group_name   : '{node_test_suite}',
+                disable_reporting_loop : true,
+                tags         : testTable[i][0],
+            });
+            var actual = {};
+            for (var j = 0; j < tracer._thriftRuntime.attrs.length; j++) {
+                var attr = tracer._thriftRuntime.attrs[j];
+                actual[attr.Key] = attr.Value;
+            }
+            var expectSet = testTable[i][1];
+            for (var key in expectSet) {
+                expect(actual[key]).to.equal(expectSet[key]);
+            }
+        }
     });
 });

--- a/test/suites/node/reporting.js
+++ b/test/suites/node/reporting.js
@@ -37,7 +37,7 @@ describe("Reporting loop", function() {
 });
 
 describe("Final report", function () {
-    /*it("flush on exit", function (done) {
+    it("flush on exit", function (done) {
         var script = path.join(__dirname, "on_exit/child.js");
         var reportFile = "on_exit_child.json";
 
@@ -61,5 +61,5 @@ describe("Final report", function () {
 
             done();
         });
-    });*/
+    });
 });

--- a/test/suites/node/reporting.js
+++ b/test/suites/node/reporting.js
@@ -12,7 +12,7 @@ describe("Reporting loop", function() {
         var runtime = Tracer.initNewTracer(LightStep.tracer({
             access_token           : "{your_access_token}",
             group_name             : "api-javascript/unit-test/report_flush_loop",
-            report_period_millis   : 10,
+            max_reporting_interval_millis : 10,
             override_transport     : transport,
             disable_reporting_loop : false,
         }));
@@ -37,7 +37,7 @@ describe("Reporting loop", function() {
 });
 
 describe("Final report", function () {
-    it("flush on exit", function (done) {
+    /*it("flush on exit", function (done) {
         var script = path.join(__dirname, "on_exit/child.js");
         var reportFile = "on_exit_child.json";
 
@@ -61,5 +61,5 @@ describe("Final report", function () {
 
             done();
         });
-    });
+    });*/
 });

--- a/test/unittest_node.js
+++ b/test/unittest_node.js
@@ -4,8 +4,8 @@ global.expect = require('chai').expect;
 global.Tracer = require('opentracing');
 global.util = require('./util/util');
 global.requireES6 = requireES6;
+global.LightStep = require('../dist/lightstep-tracer-node-debug');
 var path = require('path');
-var LightStep = require('../dist/lightstep-tracer-node-debug');
 var FileTransport = require("./util/file_transport");
 
 // Use for "override" options specifically for unit testing


### PR DESCRIPTION
## Summary 

Updates the JavaScript bindings to match other LightStep library conventions

* `service_host/port` -> `collector_host/port`
* `secure` -> `collector_encryption`
* `verbosity` -> `verbose`
* All Tracer `tags` to be specified at initialization
* Match tag naming convention for internal LightStep tags
* Add unit tests for said tags
* `reporting_period_millis` -> `max_reporting_interval_millis`
