### PR TITLE
Defect/remove use of symbol

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ var url = span.imp().generateTraceURL())
 console.log('View the trace for this span at:', url);
 ```
 
-
 ## License
 
 [The MIT License](LICENSE).

--- a/src/imp/platform/node/platform_node.js
+++ b/src/imp/platform/node/platform_node.js
@@ -96,7 +96,8 @@ export default class PlatformNode {
         }
 
         let opts = {};
-        for (let value of process.argv) {
+        for (let key in process.argv) {
+            const value = process.argv[key];
             switch (value.toLowerCase()) {
             case '--lightstep-log_to_console':
             case '--lightstep-log_to_console=true':

--- a/src/imp/tracer_imp.js
+++ b/src/imp/tracer_imp.js
@@ -329,7 +329,7 @@ export default class TracerImp extends EventEmitter {
         // Track what options have been modified
         let modified = {};
         let unchanged = {};
-        for (let  key in this._optionDescs) {
+        for (let key in this._optionDescs) {
             const desc = this._optionDescs[key];
             this._setOptionInternal(modified, unchanged, opts, desc);
         }

--- a/src/imp/tracer_imp.js
+++ b/src/imp/tracer_imp.js
@@ -329,7 +329,8 @@ export default class TracerImp extends EventEmitter {
         // Track what options have been modified
         let modified = {};
         let unchanged = {};
-        for (let desc of this._optionDescs) {
+        for (let  key in this._optionDescs) {
+            const desc = this._optionDescs[key];
             this._setOptionInternal(modified, unchanged, opts, desc);
         }
 
@@ -523,8 +524,8 @@ export default class TracerImp extends EventEmitter {
 
     addPlatformPlugins(opts) {
         let pluginSet = this._platform.plugins(opts);
-        for (let plugin of pluginSet) {
-            this.addPlugin(plugin);
+        for (let key in pluginSet) {
+            this.addPlugin(pluginSet[key]);
         }
     }
 
@@ -693,11 +694,8 @@ export default class TracerImp extends EventEmitter {
         if (this._spanRecords.length > 0) {
             return false;
         }
-
-        // `let <value> of <object>` is problematic in Node v4.1.
-        // https://github.com/babel/babel-loader/issues/84
-        for (let value of Object.entries(this._counters)) {
-            if (value > 0) {
+        for (let key in this._counters) {
+            if (this._counters[key] > 0) {
                 return false;
             }
         }
@@ -763,13 +761,14 @@ export default class TracerImp extends EventEmitter {
     }
 
     _restoreRecords(logs, spans, counters) {
-        for (let record of logs) {
-            this._internalAddLogRecord(record);
+        for (let key in logs) {
+            this._internalAddLogRecord(logs[key]);
         }
-        for (let record of spans) {
-            this._internalAddSpanRecord(record);
+        for (let key in spans) {
+            this._internalAddSpanRecord(spans[key]);
         }
-        for (let record of counters) {
+        for (let key in counters) {
+            const record = counters[key];
             if (this._counters[record.Name]) {
                 this._counters[record.Name] += record.Value;
             } else {
@@ -929,11 +928,11 @@ export default class TracerImp extends EventEmitter {
         // spans before the GUID is necessarily set.
         console.assert(this._runtimeGUID !== null, "No runtime GUID for Tracer");
 
-        for (let record of logRecords) {
-            record.runtime_guid = this._runtimeGUID;
+        for (let key in logRecords) {
+            logRecords[key].runtime_guid = this._runtimeGUID;
         }
-        for (let record of spanRecords) {
-            record.runtime_guid = this._runtimeGUID;
+        for (let key in spanRecords) {
+            spanRecords[key].runtime_guid = this._runtimeGUID;
         }
 
         let thriftCounters = [];

--- a/src/imp/util/clock_state.js
+++ b/src/imp/util/clock_state.js
@@ -94,7 +94,8 @@ class ClockState {
         // offset is the "best" one.
         let minDelayMicros = Number.MAX_VALUE;
         let bestOffsetMicros = 0;
-        for (let sample of this._samples) {
+        for (let key in this._samples) {
+            const sample = this._samples[key];
             if (sample.delayMicros < minDelayMicros) {
                 minDelayMicros = sample.delayMicros;
                 bestOffsetMicros = sample.offsetMicros;
@@ -109,7 +110,8 @@ class ClockState {
         // Now compute the jitter, i.e. the error relative to the new
         // offset were we to use it.
         let jitter = 0;
-        for (let sample of this._samples) {
+        for (let key in this._samples) {
+            const sample = this._samples[key];
             jitter += Math.pow(bestOffsetMicros - sample.offsetMicros, 2);
         }
         jitter = Math.sqrt(jitter / this._samples.length);

--- a/src/plugins/instrument_xhr.js
+++ b/src/plugins/instrument_xhr.js
@@ -300,13 +300,15 @@ class InstrumentXHR {
         if (!url) {
             return false;
         }
-        for (let ex of this._internalExclusions) {
+        for (let key in this._internalExclusions) {
+            const ex = this._internalExclusions[key];
             if (ex.test(url)) {
                 return false;
             }
         }
         let include = false;
-        for (let inc of opts.xhr_url_inclusion_patterns) {
+        for (let key in opts.xhr_url_inclusion_patterns) {
+            const inc = opts.xhr_url_inclusion_patterns[key];
             if (inc.test(url)) {
                 include = true;
                 break;
@@ -315,7 +317,8 @@ class InstrumentXHR {
         if (!include) {
             return false;
         }
-        for (let ex of opts.xhr_url_exclusion_patterns) {
+        for (let key in opts.xhr_url_exclusion_patterns) {
+            const ex = opts.xhr_url_exclusion_patterns[key];
             if (ex.test(url)) {
                 return false;
             }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -100,11 +100,40 @@ module.exports = {
                 test    : /\.js$/,
                 loader  : 'babel',
                 include : /src\//,
-                excluse : /node_modules/,
+                exclude : /node_modules/,
                 query   : {
                     cacheDirectory : true,
-                    presets : [ 'es2015' ],
-                    plugins : [ 'add-module-exports' ],
+                    presets : [ ],
+                    plugins : [
+                        'add-module-exports',
+
+                        //
+                        // Manually specify the *subset* of the ES2015 preset
+                        // to use. This reduces the output file size and improves
+                        // interoperability (e.g. Symbol polyfills on IE still
+                        // don't work great).
+                        //
+                        'babel-plugin-transform-es2015-template-literals',
+                        'babel-plugin-transform-es2015-literals',
+                        //'babel-plugin-transform-es2015-function-name',
+                        'babel-plugin-transform-es2015-arrow-functions',
+                        'babel-plugin-transform-es2015-block-scoped-functions',
+                        'babel-plugin-transform-es2015-classes',
+                        'babel-plugin-transform-es2015-object-super',
+                        // 'babel-plugin-transform-es2015-shorthand-properties',
+                        'babel-plugin-transform-es2015-duplicate-keys',
+                        'babel-plugin-transform-es2015-computed-properties',
+                        // 'babel-plugin-transform-es2015-for-of',
+                        'babel-plugin-transform-es2015-sticky-regex',
+                        'babel-plugin-transform-es2015-unicode-regex',
+                        'babel-plugin-check-es2015-constants',
+                        'babel-plugin-transform-es2015-spread',
+                        'babel-plugin-transform-es2015-parameters',
+                        'babel-plugin-transform-es2015-destructuring',
+                        'babel-plugin-transform-es2015-block-scoping',
+                        //'babel-plugin-transform-es2015-typeof-symbol',
+                        'babel-plugin-transform-es2015-modules-commonjs',
+                    ],
                 }
             },
             {


### PR DESCRIPTION
# Summary

Removes use of ES6 `Symbol` and `let...of` support from the webpack-babel compilation of the code.

* This should address compatibility concerns from #13.  
* This also reduces the minified browser distribution size by 6%.