### PR TITLE
Treat port 0 as meaning 'use the default'

### DIFF
--- a/src/imp/tracer_imp.js
+++ b/src/imp/tracer_imp.js
@@ -319,6 +319,11 @@ export default class TracerImp extends EventEmitter {
             throw new Error('options() must be called with an object: type was ' + typeof opts);
         }
 
+        // "collector_port" 0 acts as an alias for "use the default".
+        if (opts.collector_port === 0) {
+            delete opts.collector_port;
+        }
+
         // "collector_encryption" acts an alias for the common cases of 'collector_port'
         if (opts.collector_encryption !== undefined && opts.collector_port === undefined) {
             opts.collector_port = opts.collector_encryption !== 'none' ?


### PR DESCRIPTION
## Summary

Resolves #16.  If `collector_port` set to 0, it will be treated as meaning "use the default."  This can be used in conjunction with and respects the `collector_encryption` option.

FYI @djspoons.