### PR TITLE
Handle JSON responses from the server

### DIFF
--- a/src/imp/platform/browser/transport_httpjson.js
+++ b/src/imp/platform/browser/transport_httpjson.js
@@ -41,10 +41,19 @@ export default class TransportBrowser {
         xhr.onreadystatechange = function() {
             if (this.readyState === 4) {
                 let err = null;
+                let resp = null;
                 if (this.status !== 200) {
                     err = new Error('status code = ' + this.status);
+                } else if (!this.responseText) {
+                    err = new Error('unexpected empty response');
+                } else {
+                    try {
+                        resp = JSON.parse(this.responseText);
+                    } catch (exception) {
+                        err = exception;
+                    }
                 }
-                done(err, null);
+                return done(err, resp);
             }
         };
         xhr.send(payload);

--- a/src/imp/platform/node/transport_httpjson.js
+++ b/src/imp/platform/node/transport_httpjson.js
@@ -32,11 +32,20 @@ export default class TransportHTTPJSON {
                 buffer += chunk;
             });
             res.on('end', () => {
-                var err = null;
+                let err = null;
+                let resp = null;
                 if (res.statusCode !== 200) {
                     err = new Error('status code = ' + res.statusCode);
+                } else if (!buffer) {
+                    err = new Error('unexpected empty response');
+                } else {
+                    try {
+                        resp = JSON.parse(buffer);
+                    } catch (exception) {
+                        err = exception;
+                    }
                 }
-                done(err, null);
+                return done(err, resp);
             });
         });
         req.on('error', (err) => {

--- a/src/imp/tracer_imp.js
+++ b/src/imp/tracer_imp.js
@@ -867,7 +867,7 @@ export default class TracerImp extends EventEmitter {
         let jitter = 1.0 + (Math.random() * 0.2 - 0.1);
         let delay = Math.floor(Math.max(0, jitter * basis));
 
-        this._infoV(2, `Delaying next flush for ${delay}ms`);
+        this._infoV(3, `Delaying next flush for ${delay}ms`);
         this._reportTimer = util.detachedTimeout(()=> {
             this._reportTimer = null;
             this._flushReport(false, done);
@@ -949,6 +949,7 @@ export default class TracerImp extends EventEmitter {
             counters        : thriftCounters,
             timestamp_offset_micros : timestampOffset,
         });
+        this._infoV(2, `timestamp_offset_micros = ${timestampOffset}`);
 
         this.emit("prereport", report);
         let originMicros = this._platform.nowMicros();
@@ -979,7 +980,7 @@ export default class TracerImp extends EventEmitter {
 
                 if (this._options.debug) {
                     let reportWindowSeconds = (now - report.oldest_micros) / 1e6;
-                    this._info(`Report flushed for last ${reportWindowSeconds} seconds`);
+                    this._infoV(2, `Report flushed for last ${reportWindowSeconds} seconds`);
                 }
 
                 // Update internal data after the successful report
@@ -1011,7 +1012,7 @@ export default class TracerImp extends EventEmitter {
     //-----------------------------------------------------------------------//
 
     _infoV(v, msg, payload) {
-        if (this._options.verbosity < v) {
+        if (v > this._options.verbose) {
             return;
         }
         this._internalLog(constants.LOG_INFO, '[LS:V'+v+'] ' + msg, payload);


### PR DESCRIPTION
## Summary

Responses from the JSON endpoint were not being handled and now are.  (In practical terms, clock skew adjustment was not being handled previously and now will be.)

Also fixes a bug in the instrumentation internal debugging logs where the `verbose` option was not being checked correctly.