### PR TITLE
Rework document_load instrumentation initialization

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,6 +17,6 @@
       "no-unused-vars": [2, { "vars": "all", "args" : "none" }],
       "no-console": [1],
       "func-names": [0],
-      "no-multi-spaces": [2, { "exceptions": { "VariableDeclarator": true }} ]
+      "no-multi-spaces": [2, { "exceptions": { "AssignmentExpression": true }} ]
   }
 }

--- a/src/imp/span_imp.js
+++ b/src/imp/span_imp.js
@@ -152,33 +152,33 @@ export default class SpanImp {
         for (let key in fields) {
             let value = fields[key];
             switch (key) {
-                case 'operationName':
-                    this._operation = value;
-                    break;
-                case 'startTime':
-                    // startTime is in milliseconds
-                    this._beginMicros = value * 1000;
-                    break;
-                case 'tags':
-                    this.addTags(value);
-                    break;
-                case 'span_guid':
-                    this._guid = coerce.toString(value);
-                    break;
-                case 'trace_guid':
-                    this._traceGUID = coerce.toString(value);
-                    break;
-                case 'parent':
-                    if (value) {
-                        this.parent(value.imp());
-                    }
-                    break;
-                case 'parent_guid':
-                    this.setParentGUID(value);
-                    break;
-                default:
-                    this._tracer._warn(`Ignoring unknown field ${key}`);
-                    break;
+            case 'operationName':
+                this._operation = value;
+                break;
+            case 'startTime':
+                // startTime is in milliseconds
+                this._beginMicros = value * 1000;
+                break;
+            case 'tags':
+                this.addTags(value);
+                break;
+            case 'span_guid':
+                this._guid = coerce.toString(value);
+                break;
+            case 'trace_guid':
+                this._traceGUID = coerce.toString(value);
+                break;
+            case 'parent':
+                if (value) {
+                    this.parent(value.imp());
+                }
+                break;
+            case 'parent_guid':
+                this.setParentGUID(value);
+                break;
+            default:
+                this._tracer._warn(`Ignoring unknown field ${key}`);
+                break;
             }
         }
     }
@@ -227,11 +227,6 @@ export default class SpanImp {
         return child;
     }
 
-    // Used by the OpenTracing adapter layer ????
-    newEmptySpan() {
-        return new SpanImp(this._tracer);
-    }
-
     /**
      * Finishes the span.
      *
@@ -260,8 +255,6 @@ export default class SpanImp {
         this._tracer._addSpanRecord(this._toThrift());
     }
 
-
-
     // Info log record with an optional payload
     info(msg, payload) {
         this._tracer.log()
@@ -271,6 +264,7 @@ export default class SpanImp {
             .payload(payload)
             .end();
     }
+
     warn(msg, payload) {
         this._tracer.log()
             .span(this._guid)
@@ -279,6 +273,7 @@ export default class SpanImp {
             .payload(payload)
             .end();
     }
+
     error(msg, payload) {
         this._tracer.log()
             .span(this._guid)
@@ -287,6 +282,7 @@ export default class SpanImp {
             .payload(payload)
             .end();
     }
+
     // Special case to format exception information a little bit more nicely
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error
     exception(msg, exception) {
@@ -308,6 +304,7 @@ export default class SpanImp {
             })
             .end();
     }
+
     fatal(msg, payload) {
         this._tracer.log()
             .span(this._guid)

--- a/src/imp/tracer_imp.js
+++ b/src/imp/tracer_imp.js
@@ -272,11 +272,6 @@ export default class TracerImp extends EventEmitter {
         return guid;
     }
 
-    // TODO: deprecated
-    initialize(opts) {
-        this.options(opts || {});
-    }
-
     setPlatformOptions(userOptions) {
         let opts = this._platform.options(this) || {};
         if (userOptions) {
@@ -574,16 +569,6 @@ export default class TracerImp extends EventEmitter {
                 this._activeRootSpan = span;
             }
         }
-    }
-
-    // TODO: Remove once this is no longer used.
-    span(name) {
-        let handle = new SpanImp(this);
-        handle.setOperationName(name);
-
-        this.emit('span_started', handle);
-
-        return handle;
     }
 
     //-----------------------------------------------------------------------//

--- a/src/imp/util/clock_state.js
+++ b/src/imp/util/clock_state.js
@@ -7,7 +7,7 @@ const kStoredSamplesTTLMicros = 60 * 60 * 1000 * 1000; // 1 hour
 
 class ClockState {
 
-    constructor (opts) {
+    constructor(opts) {
         this._nowMicros     = opts.nowMicros;
         this._localStoreGet = opts.localStoreGet;
         this._localStoreSet = opts.localStoreSet;
@@ -27,17 +27,17 @@ class ClockState {
             storedData.timestamp_micros &&
             storedData.timestamp_micros > this._nowMicros() - kStoredSamplesTTLMicros) {
             // Make sure there are no more than (kMaxOffsetAge+1) elements
-            this._samples = storedData.samples.slice(-(kMaxOffsetAge+1));
+            this._samples = storedData.samples.slice(-(kMaxOffsetAge + 1));
         }
         // Update the current offset based on these data.
         this.update();
     }
 
     // Add a new timing sample and update the offset.
-    addSample (originMicros,
-               receiveMicros,
-               transmitMicros,
-               destinationMicros
+    addSample(originMicros,
+              receiveMicros,
+              transmitMicros,
+              destinationMicros
     ) {
         let latestDelayMicros = Number.MAX_NUMBER;
         let latestOffsetMicros = 0;
@@ -52,7 +52,7 @@ class ClockState {
         }
 
         // Discard the oldest sample and push the new one.
-        if (this._samples.length === kMaxOffsetAge+1) {
+        if (this._samples.length === kMaxOffsetAge + 1) {
             this._samples.shift();
         }
         this._samples.push({
@@ -70,7 +70,7 @@ class ClockState {
     }
 
     // Update the time offset based on the current samples.
-    update () {
+    update() {
         // This is simplified version of the clock filtering in Simple
         // NTP. It ignores precision and dispersion (frequency error). In
         // brief, it keeps the 8 (kMaxOffsetAge+1) most recent
@@ -103,7 +103,7 @@ class ClockState {
         }
 
         // No update.
-        if (bestOffsetMicros == this._currentOffsetMicros) {
+        if (bestOffsetMicros === this._currentOffsetMicros) {
             return;
         }
 
@@ -132,17 +132,17 @@ class ClockState {
     // and our clock. This should be added to any local timestamps before
     // sending them to the server. Note that a negative offset means that
     // the local clock is ahead of the server's.
-    offsetMicros () {
+    offsetMicros() {
         return Math.floor(this._currentOffsetMicros);
     }
 
     // Returns true if we've performed enough measurements to be confident
     // in the current offset.
-    isReady () {
+    isReady() {
         return this._samples.length > 3;
     }
 
-    activeSampleCount () {
+    activeSampleCount() {
         return this._samples.length;
     }
 }

--- a/src/platform_abstraction_layer.js
+++ b/src/platform_abstraction_layer.js
@@ -3,18 +3,18 @@
 // different platforms as well as expose a Platform class to abstract a few
 // general differences in the platforms.
 //
-if (PLATFORM_NODE) {
+if (PLATFORM_NODE) {           // eslint-disable-line no-undef
     module.exports = {
-        Platform          : require('./imp/platform/node/platform_node.js'),
-        Transport         : require('./imp/platform/node/transport_httpjson.js'),
-        thrift            : require('thrift'),
-        crouton_thrift    : require('./imp/platform/node/crouton_thrift.js'),
+        Platform       : require('./imp/platform/node/platform_node.js'),
+        Transport      : require('./imp/platform/node/transport_httpjson.js'),
+        thrift         : require('thrift'),
+        crouton_thrift : require('./imp/platform/node/crouton_thrift.js'),
     };
-} else if (PLATFORM_BROWSER) {
+} else if (PLATFORM_BROWSER) { // eslint-disable-line no-undef
     module.exports = {
-        Platform          : require('./imp/platform/browser/platform_browser.js'),
-        Transport         : require('./imp/platform/browser/transport_httpjson.js'),
-        thrift            : require('./imp/platform/browser/thrift.js'),
-        crouton_thrift    : require('./imp/platform/browser/crouton_thrift.js'),
-    }
+        Platform       : require('./imp/platform/browser/platform_browser.js'),
+        Transport      : require('./imp/platform/browser/transport_httpjson.js'),
+        thrift         : require('./imp/platform/browser/thrift.js'),
+        crouton_thrift : require('./imp/platform/browser/crouton_thrift.js'),
+    };
 }


### PR DESCRIPTION
## Summary

Fixes an "initialization order" problem with the browser document load auto-instrumentation. As a result, the `browser-trivial` example was not displaying the document load info. 

The existing code was setting up the "top level" document load span after the "document load" event. This is fine if all the client instrumentation also runs after document load; it's not fine if there's instrumentation code inlined into `<script>` tags which run before the load completes.  The fix was to shuffle around when the top-level span is created (aside: this unfortunately is a little awkward as the span needs to be created before the Tracer is fully initialized).

(The change also includes some ESLint de-linting.)
