### PR TITLE
Better browserify support

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/lightstep-tracer.min.js');

--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/lightstep-tracer-node.js');

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lightstep-tracer",
   "version": "0.9.42",
-  "main": "dist/lightstep-tracer-node.js",
+  "main": "index.js",
   "engines": {
     "node": ">=0.12.0"
   },


### PR DESCRIPTION
## Summary

Small change to allow clients to more clearly explicitly `require` the browser version of LightStep, which is useful for some build setups. 

Clients can now write:

```js
let LightStep = require('lightstep-tracer/browser');
```

rather than needing to spell out:

```js
let LightStep = require('lightstep-tracer/dist/lightstep-tracer.min.js');
```