### PR TITLE
Fix regression in 'log_to_console' option

### DIFF
--- a/examples/browser-trivial/browser.html
+++ b/examples/browser-trivial/browser.html
@@ -36,6 +36,8 @@
         Tracer.initGlobalTracer(LightStep.tracer({
             access_token   : '{your_access_token}',
             group_name     : 'lightstep-tracer/examples/browser-trivial',
+            log_to_console : true,
+            verbose        : 1,
         }));
 
         var span = Tracer.startSpan('trivial_span');

--- a/src/plugins/instrument_document_load.js
+++ b/src/plugins/instrument_document_load.js
@@ -8,6 +8,9 @@ class InstrumentPageLoad {
         return 'instrument_page_load';
     }
 
+    addOptions(tracerImp) {
+    }
+
     start(tracer, tracerImp) {
         if (this._inited) {
             return;

--- a/src/plugins/instrument_xhr.js
+++ b/src/plugins/instrument_xhr.js
@@ -65,15 +65,18 @@ class InstrumentXHR {
         return 'instrument_xhr';
     }
 
+    addOptions(tracerImp) {
+        tracerImp.addOption('xhr_instrumentation', { type : 'bool', defaultValue : false });
+        tracerImp.addOption('xhr_url_inclusion_patterns', { type : 'array', defaultValue : [/.*/] });
+        tracerImp.addOption('xhr_url_exclusion_patterns', { type : 'array', defaultValue : [] });
+    }
+
     start(tracer, tracerImp) {
         if (!this._enabled) {
             return;
         }
         this._tracer = tracer;
 
-        tracerImp.addOption('xhr_instrumentation', { type : 'bool', defaultValue : false });
-        tracerImp.addOption('xhr_url_inclusion_patterns', { type : 'array', defaultValue : [/.*/] });
-        tracerImp.addOption('xhr_url_exclusion_patterns', { type : 'array', defaultValue : [] });
         this._addServiceHostToExclusions(tracerImp.options());
         tracerImp.on('options', this._handleOptions);
     }


### PR DESCRIPTION
## Summary

Fixes a regression in the `log_to_console` option (which echoes logs to the browser console). 

* Add an internal `addOptions` method to the "plug-ins" to avoid the order-of-initialization problem that was preventing `log_to_console` from being a valid option at initialization
* Update `log_to_console` to log the payload as well as the message
* Fix a place where the `payload_json` field was used to record an internal warning
* Enable `log_to_console` in the trivial example