### PR TITLE
Fix incorrect variable name that was preventing final flush in browse…

### DIFF
--- a/src/imp/platform/browser/transport_httpjson.js
+++ b/src/imp/platform/browser/transport_httpjson.js
@@ -62,8 +62,8 @@ export default class TransportBrowser {
     _reportAsyncScript(auth, report, done) {
         let authJSON   = JSON.stringify(auth);
         let reportJSON = JSON.stringify(report);
-
-        let url = `${this._hostport}/_rpc/v1/reports/uri_encoded` +
+        let protocol = (this._encryption === 'none') ? 'http' : 'https';
+        let url = `${protocol}://${this._host}:${this._port}/_rpc/v1/reports/uri_encoded` +
             `?auth=${encodeURIComponent(authJSON)}` +
             `&report=${encodeURIComponent(reportJSON)}`;
 


### PR DESCRIPTION
@bensigelman , fixes the final flush issue. The code was not properly ported when moving from Thrift to the JSON endpoint.  The `this._hostport` variable does not exist in the JSON reporting code path.