### PR TITLE
Changes/xhr instrumentation data tag

### DIFF
--- a/examples/browser/browser.html
+++ b/examples/browser/browser.html
@@ -52,6 +52,10 @@
         Tracer.initGlobalTracer(LightStep.tracer({
             access_token   : '{your_access_token}',
             group_name     : 'lightstep-tracer/examples/browser',
+            xhr_instrumentation : true,
+            debug : true,
+            log_to_console : true,
+            verbose : 2,
         }));
 
         //

--- a/examples/browser/browser.html
+++ b/examples/browser/browser.html
@@ -2,7 +2,15 @@
 <html>
     <head>
         <title>LightStep - Simple Browser Example</title>
+        <link href='https://fonts.googleapis.com/css?family=Inconsolata' rel='stylesheet' type='text/css'>
         <style>
+            body, button, input, textarea {
+                font-family: 'Inconsolata';
+            }
+            input, button {
+                margin    : 2px 0;
+                font-size : 11pt;
+            }
             .main {
                 max-width : 720px;
                 margin    : 32px auto;
@@ -10,6 +18,9 @@
             textarea {
                 width      : 100%;
                 min-height : 40em;
+                margin     : 12px 0;
+                padding    : 4px 8px;
+                font-size  : 11pt;
             }
         </style>
     </head>
@@ -53,9 +64,6 @@
             access_token   : '{your_access_token}',
             group_name     : 'lightstep-tracer/examples/browser',
             xhr_instrumentation : true,
-            debug : true,
-            log_to_console : true,
-            verbose : 2,
         }));
 
         //
@@ -217,7 +225,6 @@
                 }
             };
         }
-
         -->
         </script>
     </body>

--- a/src/imp/log_builder.js
+++ b/src/imp/log_builder.js
@@ -75,7 +75,9 @@ class LogBuilder {
         try {
             payloadJSON = JSON.stringify(data);
         } catch (_ignored) {
-            return null;
+            // TODO: this should log an internal warning that a payload could
+            // not be encoded as JSON.
+            return undefined;
         }
         return payloadJSON;
     }

--- a/src/imp/platform/browser/options_parser.js
+++ b/src/imp/platform/browser/options_parser.js
@@ -48,7 +48,10 @@ module.exports.parseScriptElementOptions = function (opts, browserOpts) {
     if (typeof accessToken === 'string' && accessToken.length > 0) {
         opts.access_token = accessToken;
     }
-    let groupName = dataset.group_name;
+
+    // TODO: this should be only 'component_name'. A larger task to completely
+    // replace group_name with component_name needs to be done.
+    let groupName = dataset.component_name || dataset.group_name;
     if (typeof groupName === 'string' && groupName.length > 0) {
         opts.group_name = groupName;
     }
@@ -90,6 +93,13 @@ module.exports.parseScriptElementOptions = function (opts, browserOpts) {
         } else if (init === 'false') {
             browserOpts.init_global_tracer = false;
         }
+    }
+
+    // NOTE: this is a little inelegant as this is hard-coding support for a
+    // "plug-in" option.
+    let xhrInstrumentation = dataset.xhr_instrumentation;
+    if (typeof xhrInstrumentation === 'string' && xhrInstrumentation === 'true') {
+        browserOpts.xhr_instrumentation = true;
     }
 };
 

--- a/src/plugins/instrument_xhr.js
+++ b/src/plugins/instrument_xhr.js
@@ -300,7 +300,7 @@ class InstrumentXHR {
                 }
             }
             let lenStr = (len === undefined) ? '' : `, data length=${len}`;
-            span.imp().info(`XMLHttpRequest send${lenStr}`, { data : data });
+            span.imp().info(`XMLHttpRequest send${lenStr}`, data ? { data : data } : undefined);
             return proxied.send.apply(this, arguments);
         };
     }


### PR DESCRIPTION
Changes:

* Fix the `xhr_instrumentation` option. The prior code was simply incorrect and not generating spans properly. The option is still off by default.
* Allow a `<script>` `data-xhr_instrumentation="true"` option so simple "no coding" cut-and-paste testing of the JS library (that'll generate spans) is possible.
* Fix an unrelated issue where un-JSON.stringify-able objects ended up as `null` payloads rather than no payload
