### PR TITLE
Browser quick start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/*
 tmp-publish
 npm-debug.log
 npm-debug.log.*
+/temp

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ publish: test test_all
 	git push --tags
 	npm whoami
 	npm publish
+	bash scripts/update_docs_repo.sh
 
 test: build test_node test_browser lint
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Tracer.initGlobalTracer(LightStep.tracer({
 }));
 ```
 
-The **[LightStep JavaScript Tracing Cookbook](doc/cookbook.md)** is a good next stop for information on how to quickly instrument your system.
+The **[LightStep JavaScript Tracing Cookbook](doc/cookbook.md)** is a good next stop for information on how to quickly instrument your system.  If you want to try something out quickly in your browser code, see the **[browser quick start example](doc/cookbook.md#browser-quick-start)**.
 
 * For more information about using the OpenTracing API, see http://opentracing.io/
 * See [examples/browser](https://github.com/lightstep/lightstep-tracer-javascript/tree/master/examples/browser) for a complete JavaScript browser example

--- a/doc/cookbook.md
+++ b/doc/cookbook.md
@@ -4,6 +4,8 @@ Creating a useful trace in LightStep takes only a few minutes. Once a single tra
 
 The cookbook recipes here assume you've already successfully installed the OpenTracing and LightStep NPM packages.  If not, check out the [README](../README.md).
 
+* Getting started
+    * [Browser quick start](#browser-quick-start)
 * Creating spans
     * [Spans in Promise-based code](#promises)
     * [Spans in callback-based code](#callbacks)
@@ -15,6 +17,25 @@ The cookbook recipes here assume you've already successfully installed the OpenT
 
 *Something missing from the Cookbook? [Log a GitHub issue](https://github.com/opentracing/opentracing-javascript/issues/new) and we'll get on it :)*
 
+<a name='browser-quick-start'></a>
+## Browser quick start
+
+By using CDN hosted scripts and a few auto-instrumentation options, you can generate some traces from the browser almost immediately. This approach is great to just try things out (though you may want more control than this when deploying to production).
+
+1. Ensure you have created a valid project on LightStep and have your access token
+2. Include the following scripts in your HTML and replace `{your_access_token}` with, well, your access token value and replace `{name_to_use_for_your_component}` with a string identifier that'll be used in the LightStep UI to identify this component:
+
+```html
+<script src="http://docs.lightstep.com/dist/opentracing-javascript/current/opentracing-browser.min.js"></script>
+<script src="http://docs.lightstep.com/dist/lightstep-tracer-javascript/current/lightstep-tracer.min.js"
+        data-init_global_tracer="true"
+        data-access_token="{your_access_token}"
+        data-component_name="{name_to_use_for_your_component}"
+        data-xhr_instrumentation="true"
+        ></script>
+```
+
+The above will automatically create and report spans for any `XMLHttpRequests` made by the hosted page as well as spans for the page load.
 
 <a name='promises'></a>
 ## Instrumenting Promise-based code
@@ -23,7 +44,7 @@ Instrumenting code that uses standard [`Promise`](https://developer.mozilla.org/
 
 1. Before initiating the request that returns the `Promise`, create a span
 2. Be sure to assign your span a helpful name that describes the operation it is measuring
-2. In handling the Promise completion, be sure to always call `finish()` on the span
+3. In handling the Promise completion, be sure to always call `finish()` on the span
 
 *Note: if you're using a custom promise library or wrapper, it's easy to make spans part of the promise implementation itself.*
 

--- a/doc/cookbook.md
+++ b/doc/cookbook.md
@@ -20,10 +20,16 @@ The cookbook recipes here assume you've already successfully installed the OpenT
 <a name='browser-quick-start'></a>
 ## Browser quick start
 
-By using CDN hosted scripts and a few auto-instrumentation options, you can generate some traces from the browser almost immediately. This approach is great to just try things out (though you may want more control than this when deploying to production).
+To try out LightStep in the browser with minimal changes, you can use hosted versions of the LightStep and OpenTracing scripts along with some auto-instrumentation options.
 
-1. Ensure you have created a valid project on LightStep and have your access token
-2. Include the following scripts in your HTML and replace `{your_access_token}` with, well, your access token value and replace `{name_to_use_for_your_component}` with a string identifier that'll be used in the LightStep UI to identify this component:
+The below will generate basic spans for page-load events in the browser as well as `XMLHttpRequest` operations.
+
+While in production, you'll likely want more control than this, this is an easy option to try things out quickly!
+
+**Steps**
+
+1. Ensure you have created a valid project on app.lightstep.com and have your access token
+2. Include the following scripts in your page HTML and replace `{your_access_token}` with, well, your access token value and replace `{name_to_use_for_your_component}` with a string identifier that'll be used in the LightStep UI to identify this component:
 
 ```html
 <script src="http://docs.lightstep.com/dist/opentracing-javascript/current/opentracing-browser.min.js"></script>

--- a/scripts/update_docs_repo.sh
+++ b/scripts/update_docs_repo.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+#-------------------------------------------------------------------------------
+# Copies the compiled assets to lightstep.github.io so the assets are easily,
+# publicly accessible from a standard location.
+#-------------------------------------------------------------------------------
+set -e
+
+#
+# Clone the docs repo
+#
+rm -rf temp
+mkdir -p temp
+pushd temp
+git clone git@github.com:lightstep/lightstep.github.io
+popd
+BASEDIR=temp/lightstep.github.io/dist
+
+#
+# Copy the latest LightStep artifacts
+#
+VERSION=`node -e "p=require('./package.json'); console.log(p.version)"`
+OUTDIR=$BASEDIR/lightstep-tracer-javascript/$VERSION
+mkdir -p $OUTDIR && cp dist/* $OUTDIR
+OUTDIR=$BASEDIR/lightstep-tracer-javascript/current
+mkdir -p $OUTDIR && cp dist/* $OUTDIR
+
+#
+# Copy the latest OpenTracing artifacts
+#
+pushd node_modules/opentracing
+VERSION=`node -e "p=require('./package.json'); console.log(p.version)"`
+popd
+OUTDIR=$BASEDIR/opentracing-javascript/$VERSION
+mkdir -p $OUTDIR && cp node_modules/opentracing/dist/* $OUTDIR
+OUTDIR=$BASEDIR/opentracing-javascript/current
+mkdir -p $OUTDIR && cp node_modules/opentracing/dist/* $OUTDIR
+
+#
+# Publish the files via a git push
+#
+pushd temp/lightstep.github.io
+git add .
+git commit -m "Update dist files"
+git push
+popd
+
+rm -rf temp


### PR DESCRIPTION
## Summary

* Update the `make publish` target to also copy the latest compiled assets to docs.lightstep.com
* Update the docs with a minimal way to get started in the browser