### PR TITLE
Add some baseline benchmarks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: build publish \
 	test test_quick test_node test_browser test_all \
+	benchmark \
 	update_examples \
 	lint \
 	watch thrift
@@ -34,6 +35,9 @@ publish: test test_all
 	npm whoami
 	npm publish
 	bash scripts/update_docs_repo.sh
+
+benchmark:
+	node benchmarks/benchmark.js
 
 test: build test_node test_browser lint
 

--- a/benchmarks/benchmark.js
+++ b/benchmarks/benchmark.js
@@ -1,0 +1,145 @@
+'use strict';
+
+const Suite = require('sc-benchmark').Suite;
+const OpenTracing = require('opentracing');
+const LightStep = require('..');
+
+
+function createNoopTracer() {
+    return OpenTracing.initNewTracer(null);
+}
+function createNonReportingTracer() {
+    return OpenTracing.initNewTracer(LightStep.tracer({
+        component_name         : 'lightstep-tracer/benchmarks',
+        access_token           : 'unused',
+        disable_reporting_loop : true,
+    }));
+}
+function createNestedObject(n) {
+    if (n === 0) {
+        return 42;
+    }
+    let m = {};
+    for (let i = 0; i < 2*n; i++) {
+        m[`key-${i}`] = createNestedObject(n - 1);
+    }
+    return m;
+}
+function busyWait(ms) {
+    let start = process.hrtime();
+    let delta;
+    do {
+        let t = process.hrtime(start);
+        delta = t[0] * 1e3 + t[1] / 1e6;
+    } while (delta < ms);
+}
+
+let s = new Suite();
+
+s.bench('sanity check (10ms)', (N, t) => {
+    for (let i = 0; i < N; i++) {
+        busyWait(10.0);
+    }
+});
+
+let setups = [
+    {
+        name        : 'noop',
+        makeTracer  : createNoopTracer,
+    },
+    {
+        name        : 'ls',
+        makeTracer  : createNonReportingTracer,
+    }
+];
+
+for (let setup of setups) {
+    s.bench(`startSpan (${setup.name})`, (N, t) => {
+        let tracer = setup.makeTracer();
+        t.start();
+        for (let i = 0; i < N; i++) {
+            let span = tracer.startSpan('test');
+            span.finish();
+        }
+    });
+
+    if (setup.name === 'ls') {
+        // Test without the OT interface indirection
+        s.bench(`startSpan imp (${setup.name})`, (N, t) => {
+            let tracer = createNonReportingTracer();
+            let tracerImp = tracer.imp();
+            t.start();
+            for (let i = 0; i < N; i++) {
+                let spanImp = tracerImp.startSpan('test');
+                spanImp.finish();
+            }
+        });
+    }
+
+    s.bench(`span with logs (${setup.name})`, (N, t) => {
+        let tracer = setup.makeTracer();
+        t.start();
+        for (let i = 0; i < N; i++) {
+            let span = tracer.startSpan('test');
+            span.logEvent('Hello world!');
+            span.finish();
+        }
+    });
+
+    s.bench(`span with 100 logs (${setup.name})`, (N, t) => {
+        let tracer = setup.makeTracer();
+        t.start();
+        for (let i = 0; i < N; i++) {
+            let span = tracer.startSpan('test');
+            for (let j = 0; j < 100; j++) {
+                span.logEvent('Hello world!');
+            }
+            span.finish();
+        }
+    });
+
+    if (setup.name === 'ls') {
+        // Test without the OT interface indirection
+        s.bench(`span with 100 logs imp (${setup.name})`, (N, t) => {
+            let tracer = createNonReportingTracer();
+            let tracerImp = tracer.imp();
+            t.start();
+            for (let i = 0; i < N; i++) {
+                let spanImp = tracerImp.startSpan('test');
+                for (let j = 0; j < 100; j++) {
+                    spanImp.log({ event: 'Hello world!' });
+                }
+                spanImp.finish();
+            }
+        });
+    }
+
+    s.bench(`log with payload (${setup.name})`, (N, t) => {
+        let tracer = setup.makeTracer();
+        let payload = createNestedObject(5);
+        t.start();
+        for (let i = 0; i < N; i++) {
+            let span = tracer.startSpan('test');
+            span.logEvent('Hello world!', payload);
+            span.finish();
+        }
+    });
+
+    s.bench(`nested spans (${setup.name})`, (N, t) => {
+        let tracer = setup.makeTracer();
+        function makeNested(depth, parent) {
+            if (depth === 0) {
+                return;
+            }
+            let span = tracer.startSpan('test', { parent : parent });
+            makeNested(depth - 1, span);
+            span.finish();
+        }
+        t.start();
+        for (let i = 0; i < N; i++) {
+            makeNested(32);
+        }
+    });
+}
+
+s.run();

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "json-loader": "^0.5.4",
     "mocha": "^2.3.4",
     "opentracing": "^0.9.18",
+    "sc-benchmark": "^0.1.4",
     "shelljs": "^0.5.3",
     "sprintf-js": "^1.0.3",
     "underscore": "^1.8.3",


### PR DESCRIPTION
**Summary**

* Adds a `make benchmark` target to run some trivial benchmarks.

The benchmarks are synthetic benchmarks intended to provide some baseline numbers and sanity checks about the raw function-level performance (without any network calls). Currently the benchmarks run some very trivial operations with the OpenTracing "no-op" implementation and then again with the LightStep implementation enabled.
