### PR TITLE
Use join() in examples

### DIFF
--- a/examples/node/index.js
+++ b/examples/node/index.js
@@ -163,6 +163,9 @@ function httpGet(parentSpan, urlString, callback) {
     };
 
     try {
+        var carrier = {};
+        Tracer.inject(span, Tracer.FORMAT_TEXT_MAP, carrier);
+
         var dest = url.parse(urlString);
         var options = {
             host : PROXY_HOST,
@@ -171,12 +174,11 @@ function httpGet(parentSpan, urlString, callback) {
             headers: {
                 // User-Agent is required by the GitHub APIs
                 'User-Agent': 'LightStep Example',
-
-                // Optional: convey the trace context to the proxy server
-                'LightStep-Trace-GUID': span.imp().traceGUID(),
-                'LightStep-Parent-GUID': span.imp().guid(),
             }
         };
+        for (var key in carrier) {
+            options.headers[key] = carrier[key];
+        }
 
         // Create a span representing the https request
         span.setTag('url', urlString);

--- a/examples/proxy/index.js
+++ b/examples/proxy/index.js
@@ -37,9 +37,11 @@ var server = http.createServer(function (req, res) {
         // User-Agent is required by the GitHub APIs
         'User-Agent': 'LightStep Example Proxy'
     };
+    var requestHeaders = {};
     for (var i = 0; i + 1 < req.rawHeaders.length; i += 2) {
         var key = req.rawHeaders[i];
         var value = req.rawHeaders[i+1];
+        requestHeaders[key] = value;
         if (key == 'LightStep-Access-Token') {
             accessToken = value;
         }
@@ -58,7 +60,7 @@ var server = http.createServer(function (req, res) {
     // The span "carrier" data is presumed to have been transmitted interleaved
     // among the other HTTP headers.  join() is presumed to ignore unrecognized
     // keys in the map.
-    var span = tracer.join('request_proxy', OpenTracing.FORMAT_TEXT_MAP, req.rawHeaders);
+    var span = tracer.join('request_proxy', OpenTracing.FORMAT_TEXT_MAP, requestHeaders);
     var options = {
         host: 'api.github.com',
         path: req.url + githubAuth,

--- a/examples/proxy/index.js
+++ b/examples/proxy/index.js
@@ -3,11 +3,11 @@
 //
 // Dependencies
 //
-var http      = require('http');
-var https     = require('https');
-var url       = require('url');
-var Tracer    = require('opentracing');
-var LightStep = require('lightstep-tracer');
+var http        = require('http');
+var https       = require('https');
+var url         = require('url');
+var OpenTracing = require('opentracing');
+var LightStep   = require('lightstep-tracer');
 
 var PROXY_PORT = process.env.LIGHTSTEP_PROXY_PORT || 80;
 
@@ -33,8 +33,6 @@ var server = http.createServer(function (req, res) {
     }
 
     var accessToken = '{your_access_token}';
-    var traceGUID = null;
-    var parentGUID = null;
     var headers = {
         // User-Agent is required by the GitHub APIs
         'User-Agent': 'LightStep Example Proxy'
@@ -42,18 +40,14 @@ var server = http.createServer(function (req, res) {
     for (var i = 0; i + 1 < req.rawHeaders.length; i += 2) {
         var key = req.rawHeaders[i];
         var value = req.rawHeaders[i+1];
-        if (key == 'LightStep-Trace-GUID') {
-            traceGUID = value;
-        } else if (key == 'LightStep-Parent-GUID') {
-            parentGUID = value;
-        } else if (key == 'LightStep-Access-Token') {
+        if (key == 'LightStep-Access-Token') {
             accessToken = value;
         }
     }
 
     var tracer = tracerMap[accessToken];
     if (!tracer) {
-        tracer = Tracer.initNewTracer(LightStep.tracer({
+        tracer = OpenTracing.initNewTracer(LightStep.tracer({
             access_token   : accessToken,
             component_name : 'lightstep-tracer/examples/node_proxy',
         }));
@@ -61,7 +55,10 @@ var server = http.createServer(function (req, res) {
     }
 
     // Create a span representing the https request
-    var span = tracer.startSpan('request_proxy');
+    // The span "carrier" data is presumed to have been transmitted interleaved
+    // among the other HTTP headers.  join() is presumed to ignore unrecognized
+    // keys in the map.
+    var span = tracer.join('request_proxy', OpenTracing.FORMAT_TEXT_MAP, req.rawHeaders);
     if (traceGUID) {
         span.imp().setFields({'trace_guid' : traceGUID });
     }

--- a/examples/proxy/index.js
+++ b/examples/proxy/index.js
@@ -59,13 +59,6 @@ var server = http.createServer(function (req, res) {
     // among the other HTTP headers.  join() is presumed to ignore unrecognized
     // keys in the map.
     var span = tracer.join('request_proxy', OpenTracing.FORMAT_TEXT_MAP, req.rawHeaders);
-    if (traceGUID) {
-        span.imp().setFields({'trace_guid' : traceGUID });
-    }
-    if (parentGUID) {
-        span.imp().setFields({'parent_guid' : parentGUID });
-    }
-
     var options = {
         host: 'api.github.com',
         path: req.url + githubAuth,

--- a/src/imp/tracer_imp.js
+++ b/src/imp/tracer_imp.js
@@ -225,6 +225,7 @@ export default class TracerImp extends EventEmitter {
         case this._interface.FORMAT_TEXT_MAP:
             for (let key in carrier) {
                 let value = carrier[key];
+                key = key.toLowerCase();
                 if (key.substr(0, CARRIER_TRACER_STATE_PREFIX.length) !== CARRIER_TRACER_STATE_PREFIX) {
                     continue;
                 }
@@ -246,6 +247,7 @@ export default class TracerImp extends EventEmitter {
             }
             for (let key in carrier) {
                 let value = carrier[key];
+                key = key.toLowerCase();
                 if (key.substr(0, CARRIER_BAGGAGE_PREFIX.length) !== CARRIER_BAGGAGE_PREFIX) {
                     continue;
                 }


### PR DESCRIPTION
Update the examples to use `join()` rather than relying on more implementation-specific behavior.