### PR TITLE
Improved internal measurements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 * **API CHANGE**: Option `verbose` renamed to `verbosity`
     * `0`: never echo anything to the host application's console
     * `1`: echo only the first error to the host application's console
-    * > 1: echo internal errors, warnings, and info statements to the host application's console. Higher values will yield more detailed logs
+    * `> 1`: echo internal errors, warnings, and info statements to the host application's console. Higher values will yield more detailed logs
 * **API CHANGE**: Option `debug` is no longer valid and will generate an error if used
 * Internal errors, warnings, and info logs will no longer show up in the collected traces
 * Option `log_to_console` will no longer echo internal errors, warnings, and info logs
-* Added `CHANGELOG.md`
+* Adds `CHANGELOG.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# CHANGELOG
+
+## 0.10.1
+
+* **API CHANGE**: Option `verbose` renamed to `verbosity`
+    * `0`: never echo anything to the host application's console
+    * `1`: echo only the first error to the host application's console
+    * > 1: echo internal errors, warnings, and info statements to the host application's console. Higher values will yield more detailed logs
+* **API CHANGE**: Option `debug` is no longer valid and will generate an error if used
+* Internal errors, warnings, and info logs will no longer show up in the collected traces
+* Option `log_to_console` will no longer echo internal errors, warnings, and info logs
+* Added `CHANGELOG.md`

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,9 @@ publish: test test_all
 	npm whoami
 	npm publish
 	bash scripts/update_docs_repo.sh
+	@echo
+	@echo "Publish complete. Don't forget to update CHANGELOG.md if not done already."
+	@echo
 
 # NOTE: the benchmark package is *not* part of package.json as it relies on a
 # native module -- that does not compile on all systems. Until/unless that is

--- a/examples/browser-trivial/browser.html
+++ b/examples/browser-trivial/browser.html
@@ -37,7 +37,7 @@
             access_token   : '{your_access_token}',
             component_name : 'lightstep-tracer/examples/browser-trivial',
             log_to_console : true,
-            verbose        : 1,
+            verbosity      : 3,
         }));
 
         var span = Tracer.startSpan('trivial_span');

--- a/examples/node-trivial/index.js
+++ b/examples/node-trivial/index.js
@@ -6,15 +6,22 @@ var LightStep = require('../../dist/lightstep-tracer-node-debug');
 Tracer.initGlobalTracer(LightStep.tracer({
     access_token   : '{your_access_token}',
     component_name : 'lightstep-tracer/examples/node-trivial',
+    collector_host : 'localhost',
+    collector_port : 9998,
+    collector_encryption : 'none',
+    disable_reporting_loop : true,
 }));
 
-var span = Tracer.startSpan('trivial_span');
-setTimeout(function() {
-    span.logEvent('log_event');
-}, 100);
-setTimeout(function() {
-    span.finish();
-}, 200);
+var parent = Tracer.startSpan('parent');
+for (var i = 0; i < 20000; i++) {
+    var child = Tracer.startSpan('child', { parent: parent });
+    child.logEvent('log_event');
+    child.finish();
+}
+parent.finish();
 
-var url = span.imp().generateTraceURL();
-console.log('URL: ' + url);
+var url = parent.imp().generateTraceURL();
+console.log();
+console.log(url);
+console.log();
+console.log(Tracer.imp().stats());

--- a/examples/node-trivial/index.js
+++ b/examples/node-trivial/index.js
@@ -9,7 +9,7 @@ Tracer.initGlobalTracer(LightStep.tracer({
     collector_host : 'localhost',
     collector_port : 9998,
     collector_encryption : 'none',
-    disable_reporting_loop : true,
+    //disable_reporting_loop : true,
 }));
 
 var parent = Tracer.startSpan('parent');

--- a/examples/node-trivial/index.js
+++ b/examples/node-trivial/index.js
@@ -15,7 +15,7 @@ Tracer.initGlobalTracer(LightStep.tracer({
 var parent = Tracer.startSpan('parent');
 for (var i = 0; i < 20000; i++) {
     var child = Tracer.startSpan('child', { parent: parent });
-    child.logEvent('log_event');
+    child.logEvent('log_event', largePayload);
     child.finish();
 }
 parent.finish();

--- a/examples/node-trivial/index.js
+++ b/examples/node-trivial/index.js
@@ -6,22 +6,15 @@ var LightStep = require('../../dist/lightstep-tracer-node-debug');
 Tracer.initGlobalTracer(LightStep.tracer({
     access_token   : '{your_access_token}',
     component_name : 'lightstep-tracer/examples/node-trivial',
-    collector_host : 'localhost',
-    collector_port : 9998,
-    collector_encryption : 'none',
-    //disable_reporting_loop : true,
 }));
 
-var parent = Tracer.startSpan('parent');
-for (var i = 0; i < 20000; i++) {
-    var child = Tracer.startSpan('child', { parent: parent });
-    child.logEvent('log_event', largePayload);
-    child.finish();
-}
-parent.finish();
+var span = Tracer.startSpan('trivial_span');
+setTimeout(function() {
+    span.logEvent('log_event');
+}, 100);
+setTimeout(function() {
+    span.finish();
+}, 200);
 
-var url = parent.imp().generateTraceURL();
-console.log();
-console.log(url);
-console.log();
-console.log(Tracer.imp().stats());
+var url = span.imp().generateTraceURL();
+console.log('URL: ' + url);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lightstep-tracer",
-  "version": "0.9.51",
+  "version": "0.10.0",
   "main": "index.js",
   "engines": {
     "node": ">=0.12.0"

--- a/src/imp/log_builder.js
+++ b/src/imp/log_builder.js
@@ -24,6 +24,10 @@ class LogBuilder {
         });
     }
 
+    record() {
+        return this._record;
+    }
+
     end() {
         this._runtime._addLogRecord(this._record);
     }

--- a/src/imp/platform/browser/generated/thrift_all.js
+++ b/src/imp/platform/browser/generated/thrift_all.js
@@ -87,6 +87,76 @@ crouton_thrift.KeyValue.prototype.write = false && function(output) {
   return;
 };
 
+crouton_thrift.NamedCounter = function(args) {
+  this.Name = null;
+  this.Value = null;
+  if (args) {
+    if (args.Name !== undefined) {
+      this.Name = args.Name;
+    } else {
+      throw new Thrift.TProtocolException(Thrift.TProtocolExceptionType.UNKNOWN, 'Required field Name is unset!');
+    }
+    if (args.Value !== undefined) {
+      this.Value = args.Value;
+    } else {
+      throw new Thrift.TProtocolException(Thrift.TProtocolExceptionType.UNKNOWN, 'Required field Value is unset!');
+    }
+  }
+};
+crouton_thrift.NamedCounter.prototype = {};
+crouton_thrift.NamedCounter.prototype.read = false && function(input) {
+  input.readStructBegin();
+  while (true)
+  {
+    var ret = input.readFieldBegin();
+    var fname = ret.fname;
+    var ftype = ret.ftype;
+    var fid = ret.fid;
+    if (ftype == Thrift.Type.STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+      if (ftype == Thrift.Type.STRING) {
+        this.Name = input.readString().value;
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 2:
+      if (ftype == Thrift.Type.I64) {
+        this.Value = input.readI64().value;
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      default:
+        input.skip(ftype);
+    }
+    input.readFieldEnd();
+  }
+  input.readStructEnd();
+  return;
+};
+
+crouton_thrift.NamedCounter.prototype.write = false && function(output) {
+  output.writeStructBegin('NamedCounter');
+  if (this.Name !== null && this.Name !== undefined) {
+    output.writeFieldBegin('Name', Thrift.Type.STRING, 1);
+    output.writeString(this.Name);
+    output.writeFieldEnd();
+  }
+  if (this.Value !== null && this.Value !== undefined) {
+    output.writeFieldBegin('Value', Thrift.Type.I64, 2);
+    output.writeI64(this.Value);
+    output.writeFieldEnd();
+  }
+  output.writeFieldStop();
+  output.writeStructEnd();
+  return;
+};
+
 crouton_thrift.Runtime = function(args) {
   this.guid = null;
   this.start_micros = null;
@@ -908,6 +978,88 @@ crouton_thrift.Timing.prototype.write = false && function(output) {
   return;
 };
 
+crouton_thrift.SampleCount = function(args) {
+  this.oldest_micros = null;
+  this.youngest_micros = null;
+  this.count = null;
+  if (args) {
+    if (args.oldest_micros !== undefined) {
+      this.oldest_micros = args.oldest_micros;
+    }
+    if (args.youngest_micros !== undefined) {
+      this.youngest_micros = args.youngest_micros;
+    }
+    if (args.count !== undefined) {
+      this.count = args.count;
+    }
+  }
+};
+crouton_thrift.SampleCount.prototype = {};
+crouton_thrift.SampleCount.prototype.read = false && function(input) {
+  input.readStructBegin();
+  while (true)
+  {
+    var ret = input.readFieldBegin();
+    var fname = ret.fname;
+    var ftype = ret.ftype;
+    var fid = ret.fid;
+    if (ftype == Thrift.Type.STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+      if (ftype == Thrift.Type.I64) {
+        this.oldest_micros = input.readI64().value;
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 2:
+      if (ftype == Thrift.Type.I64) {
+        this.youngest_micros = input.readI64().value;
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 3:
+      if (ftype == Thrift.Type.I64) {
+        this.count = input.readI64().value;
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      default:
+        input.skip(ftype);
+    }
+    input.readFieldEnd();
+  }
+  input.readStructEnd();
+  return;
+};
+
+crouton_thrift.SampleCount.prototype.write = false && function(output) {
+  output.writeStructBegin('SampleCount');
+  if (this.oldest_micros !== null && this.oldest_micros !== undefined) {
+    output.writeFieldBegin('oldest_micros', Thrift.Type.I64, 1);
+    output.writeI64(this.oldest_micros);
+    output.writeFieldEnd();
+  }
+  if (this.youngest_micros !== null && this.youngest_micros !== undefined) {
+    output.writeFieldBegin('youngest_micros', Thrift.Type.I64, 2);
+    output.writeI64(this.youngest_micros);
+    output.writeFieldEnd();
+  }
+  if (this.count !== null && this.count !== undefined) {
+    output.writeFieldBegin('count', Thrift.Type.I64, 3);
+    output.writeI64(this.count);
+    output.writeFieldEnd();
+  }
+  output.writeFieldStop();
+  output.writeStructEnd();
+  return;
+};
+
 crouton_thrift.MetricsSample = function(args) {
   this.name = null;
   this.int64_value = null;
@@ -1075,6 +1227,7 @@ crouton_thrift.ReportRequest = function(args) {
   this.timestamp_offset_micros = null;
   this.oldest_micros = null;
   this.youngest_micros = null;
+  this.counters = null;
   this.internal_logs = null;
   this.internal_metrics = null;
   if (args) {
@@ -1095,6 +1248,9 @@ crouton_thrift.ReportRequest = function(args) {
     }
     if (args.youngest_micros !== undefined) {
       this.youngest_micros = args.youngest_micros;
+    }
+    if (args.counters !== undefined) {
+      this.counters = args.counters;
     }
     if (args.internal_logs !== undefined) {
       this.internal_logs = args.internal_logs;
@@ -1189,11 +1345,11 @@ crouton_thrift.ReportRequest.prototype.read = false && function(input) {
         input.skip(ftype);
       }
       break;
-      case 10:
+      case 9:
       if (ftype == Thrift.Type.LIST) {
         var _size62 = 0;
         var _rtmp366;
-        this.internal_logs = [];
+        this.counters = [];
         var _etype65 = 0;
         _rtmp366 = input.readListBegin();
         _etype65 = _rtmp366.etype;
@@ -1201,9 +1357,30 @@ crouton_thrift.ReportRequest.prototype.read = false && function(input) {
         for (var _i67 = 0; _i67 < _size62; ++_i67)
         {
           var elem68 = null;
-          elem68 = new crouton_thrift.LogRecord();
+          elem68 = new crouton_thrift.NamedCounter();
           elem68.read(input);
-          this.internal_logs.push(elem68);
+          this.counters.push(elem68);
+        }
+        input.readListEnd();
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 10:
+      if (ftype == Thrift.Type.LIST) {
+        var _size69 = 0;
+        var _rtmp373;
+        this.internal_logs = [];
+        var _etype72 = 0;
+        _rtmp373 = input.readListBegin();
+        _etype72 = _rtmp373.etype;
+        _size69 = _rtmp373.size;
+        for (var _i74 = 0; _i74 < _size69; ++_i74)
+        {
+          var elem75 = null;
+          elem75 = new crouton_thrift.LogRecord();
+          elem75.read(input);
+          this.internal_logs.push(elem75);
         }
         input.readListEnd();
       } else {
@@ -1237,12 +1414,12 @@ crouton_thrift.ReportRequest.prototype.write = false && function(output) {
   if (this.span_records !== null && this.span_records !== undefined) {
     output.writeFieldBegin('span_records', Thrift.Type.LIST, 3);
     output.writeListBegin(Thrift.Type.STRUCT, this.span_records.length);
-    for (var iter69 in this.span_records)
+    for (var iter76 in this.span_records)
     {
-      if (this.span_records.hasOwnProperty(iter69))
+      if (this.span_records.hasOwnProperty(iter76))
       {
-        iter69 = this.span_records[iter69];
-        iter69.write(output);
+        iter76 = this.span_records[iter76];
+        iter76.write(output);
       }
     }
     output.writeListEnd();
@@ -1251,12 +1428,12 @@ crouton_thrift.ReportRequest.prototype.write = false && function(output) {
   if (this.log_records !== null && this.log_records !== undefined) {
     output.writeFieldBegin('log_records', Thrift.Type.LIST, 4);
     output.writeListBegin(Thrift.Type.STRUCT, this.log_records.length);
-    for (var iter70 in this.log_records)
+    for (var iter77 in this.log_records)
     {
-      if (this.log_records.hasOwnProperty(iter70))
+      if (this.log_records.hasOwnProperty(iter77))
       {
-        iter70 = this.log_records[iter70];
-        iter70.write(output);
+        iter77 = this.log_records[iter77];
+        iter77.write(output);
       }
     }
     output.writeListEnd();
@@ -1277,15 +1454,29 @@ crouton_thrift.ReportRequest.prototype.write = false && function(output) {
     output.writeI64(this.youngest_micros);
     output.writeFieldEnd();
   }
+  if (this.counters !== null && this.counters !== undefined) {
+    output.writeFieldBegin('counters', Thrift.Type.LIST, 9);
+    output.writeListBegin(Thrift.Type.STRUCT, this.counters.length);
+    for (var iter78 in this.counters)
+    {
+      if (this.counters.hasOwnProperty(iter78))
+      {
+        iter78 = this.counters[iter78];
+        iter78.write(output);
+      }
+    }
+    output.writeListEnd();
+    output.writeFieldEnd();
+  }
   if (this.internal_logs !== null && this.internal_logs !== undefined) {
     output.writeFieldBegin('internal_logs', Thrift.Type.LIST, 10);
     output.writeListBegin(Thrift.Type.STRUCT, this.internal_logs.length);
-    for (var iter71 in this.internal_logs)
+    for (var iter79 in this.internal_logs)
     {
-      if (this.internal_logs.hasOwnProperty(iter71))
+      if (this.internal_logs.hasOwnProperty(iter79))
       {
-        iter71 = this.internal_logs[iter71];
-        iter71.write(output);
+        iter79 = this.internal_logs[iter79];
+        iter79.write(output);
       }
     }
     output.writeListEnd();
@@ -1386,19 +1577,19 @@ crouton_thrift.ReportResponse.prototype.read = false && function(input) {
     {
       case 1:
       if (ftype == Thrift.Type.LIST) {
-        var _size72 = 0;
-        var _rtmp376;
+        var _size80 = 0;
+        var _rtmp384;
         this.commands = [];
-        var _etype75 = 0;
-        _rtmp376 = input.readListBegin();
-        _etype75 = _rtmp376.etype;
-        _size72 = _rtmp376.size;
-        for (var _i77 = 0; _i77 < _size72; ++_i77)
+        var _etype83 = 0;
+        _rtmp384 = input.readListBegin();
+        _etype83 = _rtmp384.etype;
+        _size80 = _rtmp384.size;
+        for (var _i85 = 0; _i85 < _size80; ++_i85)
         {
-          var elem78 = null;
-          elem78 = new crouton_thrift.Command();
-          elem78.read(input);
-          this.commands.push(elem78);
+          var elem86 = null;
+          elem86 = new crouton_thrift.Command();
+          elem86.read(input);
+          this.commands.push(elem86);
         }
         input.readListEnd();
       } else {
@@ -1415,18 +1606,18 @@ crouton_thrift.ReportResponse.prototype.read = false && function(input) {
       break;
       case 3:
       if (ftype == Thrift.Type.LIST) {
-        var _size79 = 0;
-        var _rtmp383;
+        var _size87 = 0;
+        var _rtmp391;
         this.errors = [];
-        var _etype82 = 0;
-        _rtmp383 = input.readListBegin();
-        _etype82 = _rtmp383.etype;
-        _size79 = _rtmp383.size;
-        for (var _i84 = 0; _i84 < _size79; ++_i84)
+        var _etype90 = 0;
+        _rtmp391 = input.readListBegin();
+        _etype90 = _rtmp391.etype;
+        _size87 = _rtmp391.size;
+        for (var _i92 = 0; _i92 < _size87; ++_i92)
         {
-          var elem85 = null;
-          elem85 = input.readString().value;
-          this.errors.push(elem85);
+          var elem93 = null;
+          elem93 = input.readString().value;
+          this.errors.push(elem93);
         }
         input.readListEnd();
       } else {
@@ -1447,12 +1638,12 @@ crouton_thrift.ReportResponse.prototype.write = false && function(output) {
   if (this.commands !== null && this.commands !== undefined) {
     output.writeFieldBegin('commands', Thrift.Type.LIST, 1);
     output.writeListBegin(Thrift.Type.STRUCT, this.commands.length);
-    for (var iter86 in this.commands)
+    for (var iter94 in this.commands)
     {
-      if (this.commands.hasOwnProperty(iter86))
+      if (this.commands.hasOwnProperty(iter94))
       {
-        iter86 = this.commands[iter86];
-        iter86.write(output);
+        iter94 = this.commands[iter94];
+        iter94.write(output);
       }
     }
     output.writeListEnd();
@@ -1466,12 +1657,12 @@ crouton_thrift.ReportResponse.prototype.write = false && function(output) {
   if (this.errors !== null && this.errors !== undefined) {
     output.writeFieldBegin('errors', Thrift.Type.LIST, 3);
     output.writeListBegin(Thrift.Type.STRING, this.errors.length);
-    for (var iter87 in this.errors)
+    for (var iter95 in this.errors)
     {
-      if (this.errors.hasOwnProperty(iter87))
+      if (this.errors.hasOwnProperty(iter95))
       {
-        iter87 = this.errors[iter87];
-        output.writeString(iter87);
+        iter95 = this.errors[iter95];
+        output.writeString(iter95);
       }
     }
     output.writeListEnd();

--- a/src/imp/platform/browser/generated/thrift_all.js
+++ b/src/imp/platform/browser/generated/thrift_all.js
@@ -87,76 +87,6 @@ crouton_thrift.KeyValue.prototype.write = false && function(output) {
   return;
 };
 
-crouton_thrift.NamedCounter = function(args) {
-  this.Name = null;
-  this.Value = null;
-  if (args) {
-    if (args.Name !== undefined) {
-      this.Name = args.Name;
-    } else {
-      throw new Thrift.TProtocolException(Thrift.TProtocolExceptionType.UNKNOWN, 'Required field Name is unset!');
-    }
-    if (args.Value !== undefined) {
-      this.Value = args.Value;
-    } else {
-      throw new Thrift.TProtocolException(Thrift.TProtocolExceptionType.UNKNOWN, 'Required field Value is unset!');
-    }
-  }
-};
-crouton_thrift.NamedCounter.prototype = {};
-crouton_thrift.NamedCounter.prototype.read = false && function(input) {
-  input.readStructBegin();
-  while (true)
-  {
-    var ret = input.readFieldBegin();
-    var fname = ret.fname;
-    var ftype = ret.ftype;
-    var fid = ret.fid;
-    if (ftype == Thrift.Type.STOP) {
-      break;
-    }
-    switch (fid)
-    {
-      case 1:
-      if (ftype == Thrift.Type.STRING) {
-        this.Name = input.readString().value;
-      } else {
-        input.skip(ftype);
-      }
-      break;
-      case 2:
-      if (ftype == Thrift.Type.I64) {
-        this.Value = input.readI64().value;
-      } else {
-        input.skip(ftype);
-      }
-      break;
-      default:
-        input.skip(ftype);
-    }
-    input.readFieldEnd();
-  }
-  input.readStructEnd();
-  return;
-};
-
-crouton_thrift.NamedCounter.prototype.write = false && function(output) {
-  output.writeStructBegin('NamedCounter');
-  if (this.Name !== null && this.Name !== undefined) {
-    output.writeFieldBegin('Name', Thrift.Type.STRING, 1);
-    output.writeString(this.Name);
-    output.writeFieldEnd();
-  }
-  if (this.Value !== null && this.Value !== undefined) {
-    output.writeFieldBegin('Value', Thrift.Type.I64, 2);
-    output.writeI64(this.Value);
-    output.writeFieldEnd();
-  }
-  output.writeFieldStop();
-  output.writeStructEnd();
-  return;
-};
-
 crouton_thrift.Runtime = function(args) {
   this.guid = null;
   this.start_micros = null;
@@ -978,24 +908,26 @@ crouton_thrift.Timing.prototype.write = false && function(output) {
   return;
 };
 
-crouton_thrift.SampleCount = function(args) {
-  this.oldest_micros = null;
-  this.youngest_micros = null;
-  this.count = null;
+crouton_thrift.MetricsSample = function(args) {
+  this.name = null;
+  this.int64_value = null;
+  this.double_value = null;
   if (args) {
-    if (args.oldest_micros !== undefined) {
-      this.oldest_micros = args.oldest_micros;
+    if (args.name !== undefined) {
+      this.name = args.name;
+    } else {
+      throw new Thrift.TProtocolException(Thrift.TProtocolExceptionType.UNKNOWN, 'Required field name is unset!');
     }
-    if (args.youngest_micros !== undefined) {
-      this.youngest_micros = args.youngest_micros;
+    if (args.int64_value !== undefined) {
+      this.int64_value = args.int64_value;
     }
-    if (args.count !== undefined) {
-      this.count = args.count;
+    if (args.double_value !== undefined) {
+      this.double_value = args.double_value;
     }
   }
 };
-crouton_thrift.SampleCount.prototype = {};
-crouton_thrift.SampleCount.prototype.read = false && function(input) {
+crouton_thrift.MetricsSample.prototype = {};
+crouton_thrift.MetricsSample.prototype.read = false && function(input) {
   input.readStructBegin();
   while (true)
   {
@@ -1009,22 +941,22 @@ crouton_thrift.SampleCount.prototype.read = false && function(input) {
     switch (fid)
     {
       case 1:
-      if (ftype == Thrift.Type.I64) {
-        this.oldest_micros = input.readI64().value;
+      if (ftype == Thrift.Type.STRING) {
+        this.name = input.readString().value;
       } else {
         input.skip(ftype);
       }
       break;
       case 2:
       if (ftype == Thrift.Type.I64) {
-        this.youngest_micros = input.readI64().value;
+        this.int64_value = input.readI64().value;
       } else {
         input.skip(ftype);
       }
       break;
       case 3:
-      if (ftype == Thrift.Type.I64) {
-        this.count = input.readI64().value;
+      if (ftype == Thrift.Type.DOUBLE) {
+        this.double_value = input.readDouble().value;
       } else {
         input.skip(ftype);
       }
@@ -1038,21 +970,97 @@ crouton_thrift.SampleCount.prototype.read = false && function(input) {
   return;
 };
 
-crouton_thrift.SampleCount.prototype.write = false && function(output) {
-  output.writeStructBegin('SampleCount');
-  if (this.oldest_micros !== null && this.oldest_micros !== undefined) {
-    output.writeFieldBegin('oldest_micros', Thrift.Type.I64, 1);
-    output.writeI64(this.oldest_micros);
+crouton_thrift.MetricsSample.prototype.write = false && function(output) {
+  output.writeStructBegin('MetricsSample');
+  if (this.name !== null && this.name !== undefined) {
+    output.writeFieldBegin('name', Thrift.Type.STRING, 1);
+    output.writeString(this.name);
     output.writeFieldEnd();
   }
-  if (this.youngest_micros !== null && this.youngest_micros !== undefined) {
-    output.writeFieldBegin('youngest_micros', Thrift.Type.I64, 2);
-    output.writeI64(this.youngest_micros);
+  if (this.int64_value !== null && this.int64_value !== undefined) {
+    output.writeFieldBegin('int64_value', Thrift.Type.I64, 2);
+    output.writeI64(this.int64_value);
     output.writeFieldEnd();
   }
-  if (this.count !== null && this.count !== undefined) {
-    output.writeFieldBegin('count', Thrift.Type.I64, 3);
-    output.writeI64(this.count);
+  if (this.double_value !== null && this.double_value !== undefined) {
+    output.writeFieldBegin('double_value', Thrift.Type.DOUBLE, 3);
+    output.writeDouble(this.double_value);
+    output.writeFieldEnd();
+  }
+  output.writeFieldStop();
+  output.writeStructEnd();
+  return;
+};
+
+crouton_thrift.Metrics = function(args) {
+  this.counts = null;
+  if (args) {
+    if (args.counts !== undefined) {
+      this.counts = args.counts;
+    }
+  }
+};
+crouton_thrift.Metrics.prototype = {};
+crouton_thrift.Metrics.prototype.read = false && function(input) {
+  input.readStructBegin();
+  while (true)
+  {
+    var ret = input.readFieldBegin();
+    var fname = ret.fname;
+    var ftype = ret.ftype;
+    var fid = ret.fid;
+    if (ftype == Thrift.Type.STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+      if (ftype == Thrift.Type.LIST) {
+        var _size40 = 0;
+        var _rtmp344;
+        this.counts = [];
+        var _etype43 = 0;
+        _rtmp344 = input.readListBegin();
+        _etype43 = _rtmp344.etype;
+        _size40 = _rtmp344.size;
+        for (var _i45 = 0; _i45 < _size40; ++_i45)
+        {
+          var elem46 = null;
+          elem46 = new crouton_thrift.MetricsSample();
+          elem46.read(input);
+          this.counts.push(elem46);
+        }
+        input.readListEnd();
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 0:
+        input.skip(ftype);
+        break;
+      default:
+        input.skip(ftype);
+    }
+    input.readFieldEnd();
+  }
+  input.readStructEnd();
+  return;
+};
+
+crouton_thrift.Metrics.prototype.write = false && function(output) {
+  output.writeStructBegin('Metrics');
+  if (this.counts !== null && this.counts !== undefined) {
+    output.writeFieldBegin('counts', Thrift.Type.LIST, 1);
+    output.writeListBegin(Thrift.Type.STRUCT, this.counts.length);
+    for (var iter47 in this.counts)
+    {
+      if (this.counts.hasOwnProperty(iter47))
+      {
+        iter47 = this.counts[iter47];
+        iter47.write(output);
+      }
+    }
+    output.writeListEnd();
     output.writeFieldEnd();
   }
   output.writeFieldStop();
@@ -1067,7 +1075,8 @@ crouton_thrift.ReportRequest = function(args) {
   this.timestamp_offset_micros = null;
   this.oldest_micros = null;
   this.youngest_micros = null;
-  this.counters = null;
+  this.internal_logs = null;
+  this.internal_metrics = null;
   if (args) {
     if (args.runtime !== undefined) {
       this.runtime = args.runtime;
@@ -1087,8 +1096,11 @@ crouton_thrift.ReportRequest = function(args) {
     if (args.youngest_micros !== undefined) {
       this.youngest_micros = args.youngest_micros;
     }
-    if (args.counters !== undefined) {
-      this.counters = args.counters;
+    if (args.internal_logs !== undefined) {
+      this.internal_logs = args.internal_logs;
+    }
+    if (args.internal_metrics !== undefined) {
+      this.internal_metrics = args.internal_metrics;
     }
   }
 };
@@ -1116,19 +1128,19 @@ crouton_thrift.ReportRequest.prototype.read = false && function(input) {
       break;
       case 3:
       if (ftype == Thrift.Type.LIST) {
-        var _size40 = 0;
-        var _rtmp344;
+        var _size48 = 0;
+        var _rtmp352;
         this.span_records = [];
-        var _etype43 = 0;
-        _rtmp344 = input.readListBegin();
-        _etype43 = _rtmp344.etype;
-        _size40 = _rtmp344.size;
-        for (var _i45 = 0; _i45 < _size40; ++_i45)
+        var _etype51 = 0;
+        _rtmp352 = input.readListBegin();
+        _etype51 = _rtmp352.etype;
+        _size48 = _rtmp352.size;
+        for (var _i53 = 0; _i53 < _size48; ++_i53)
         {
-          var elem46 = null;
-          elem46 = new crouton_thrift.SpanRecord();
-          elem46.read(input);
-          this.span_records.push(elem46);
+          var elem54 = null;
+          elem54 = new crouton_thrift.SpanRecord();
+          elem54.read(input);
+          this.span_records.push(elem54);
         }
         input.readListEnd();
       } else {
@@ -1137,19 +1149,19 @@ crouton_thrift.ReportRequest.prototype.read = false && function(input) {
       break;
       case 4:
       if (ftype == Thrift.Type.LIST) {
-        var _size47 = 0;
-        var _rtmp351;
+        var _size55 = 0;
+        var _rtmp359;
         this.log_records = [];
-        var _etype50 = 0;
-        _rtmp351 = input.readListBegin();
-        _etype50 = _rtmp351.etype;
-        _size47 = _rtmp351.size;
-        for (var _i52 = 0; _i52 < _size47; ++_i52)
+        var _etype58 = 0;
+        _rtmp359 = input.readListBegin();
+        _etype58 = _rtmp359.etype;
+        _size55 = _rtmp359.size;
+        for (var _i60 = 0; _i60 < _size55; ++_i60)
         {
-          var elem53 = null;
-          elem53 = new crouton_thrift.LogRecord();
-          elem53.read(input);
-          this.log_records.push(elem53);
+          var elem61 = null;
+          elem61 = new crouton_thrift.LogRecord();
+          elem61.read(input);
+          this.log_records.push(elem61);
         }
         input.readListEnd();
       } else {
@@ -1177,23 +1189,31 @@ crouton_thrift.ReportRequest.prototype.read = false && function(input) {
         input.skip(ftype);
       }
       break;
-      case 9:
+      case 10:
       if (ftype == Thrift.Type.LIST) {
-        var _size54 = 0;
-        var _rtmp358;
-        this.counters = [];
-        var _etype57 = 0;
-        _rtmp358 = input.readListBegin();
-        _etype57 = _rtmp358.etype;
-        _size54 = _rtmp358.size;
-        for (var _i59 = 0; _i59 < _size54; ++_i59)
+        var _size62 = 0;
+        var _rtmp366;
+        this.internal_logs = [];
+        var _etype65 = 0;
+        _rtmp366 = input.readListBegin();
+        _etype65 = _rtmp366.etype;
+        _size62 = _rtmp366.size;
+        for (var _i67 = 0; _i67 < _size62; ++_i67)
         {
-          var elem60 = null;
-          elem60 = new crouton_thrift.NamedCounter();
-          elem60.read(input);
-          this.counters.push(elem60);
+          var elem68 = null;
+          elem68 = new crouton_thrift.LogRecord();
+          elem68.read(input);
+          this.internal_logs.push(elem68);
         }
         input.readListEnd();
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 11:
+      if (ftype == Thrift.Type.STRUCT) {
+        this.internal_metrics = new crouton_thrift.Metrics();
+        this.internal_metrics.read(input);
       } else {
         input.skip(ftype);
       }
@@ -1217,12 +1237,12 @@ crouton_thrift.ReportRequest.prototype.write = false && function(output) {
   if (this.span_records !== null && this.span_records !== undefined) {
     output.writeFieldBegin('span_records', Thrift.Type.LIST, 3);
     output.writeListBegin(Thrift.Type.STRUCT, this.span_records.length);
-    for (var iter61 in this.span_records)
+    for (var iter69 in this.span_records)
     {
-      if (this.span_records.hasOwnProperty(iter61))
+      if (this.span_records.hasOwnProperty(iter69))
       {
-        iter61 = this.span_records[iter61];
-        iter61.write(output);
+        iter69 = this.span_records[iter69];
+        iter69.write(output);
       }
     }
     output.writeListEnd();
@@ -1231,12 +1251,12 @@ crouton_thrift.ReportRequest.prototype.write = false && function(output) {
   if (this.log_records !== null && this.log_records !== undefined) {
     output.writeFieldBegin('log_records', Thrift.Type.LIST, 4);
     output.writeListBegin(Thrift.Type.STRUCT, this.log_records.length);
-    for (var iter62 in this.log_records)
+    for (var iter70 in this.log_records)
     {
-      if (this.log_records.hasOwnProperty(iter62))
+      if (this.log_records.hasOwnProperty(iter70))
       {
-        iter62 = this.log_records[iter62];
-        iter62.write(output);
+        iter70 = this.log_records[iter70];
+        iter70.write(output);
       }
     }
     output.writeListEnd();
@@ -1257,18 +1277,23 @@ crouton_thrift.ReportRequest.prototype.write = false && function(output) {
     output.writeI64(this.youngest_micros);
     output.writeFieldEnd();
   }
-  if (this.counters !== null && this.counters !== undefined) {
-    output.writeFieldBegin('counters', Thrift.Type.LIST, 9);
-    output.writeListBegin(Thrift.Type.STRUCT, this.counters.length);
-    for (var iter63 in this.counters)
+  if (this.internal_logs !== null && this.internal_logs !== undefined) {
+    output.writeFieldBegin('internal_logs', Thrift.Type.LIST, 10);
+    output.writeListBegin(Thrift.Type.STRUCT, this.internal_logs.length);
+    for (var iter71 in this.internal_logs)
     {
-      if (this.counters.hasOwnProperty(iter63))
+      if (this.internal_logs.hasOwnProperty(iter71))
       {
-        iter63 = this.counters[iter63];
-        iter63.write(output);
+        iter71 = this.internal_logs[iter71];
+        iter71.write(output);
       }
     }
     output.writeListEnd();
+    output.writeFieldEnd();
+  }
+  if (this.internal_metrics !== null && this.internal_metrics !== undefined) {
+    output.writeFieldBegin('internal_metrics', Thrift.Type.STRUCT, 11);
+    this.internal_metrics.write(output);
     output.writeFieldEnd();
   }
   output.writeFieldStop();
@@ -1361,19 +1386,19 @@ crouton_thrift.ReportResponse.prototype.read = false && function(input) {
     {
       case 1:
       if (ftype == Thrift.Type.LIST) {
-        var _size64 = 0;
-        var _rtmp368;
+        var _size72 = 0;
+        var _rtmp376;
         this.commands = [];
-        var _etype67 = 0;
-        _rtmp368 = input.readListBegin();
-        _etype67 = _rtmp368.etype;
-        _size64 = _rtmp368.size;
-        for (var _i69 = 0; _i69 < _size64; ++_i69)
+        var _etype75 = 0;
+        _rtmp376 = input.readListBegin();
+        _etype75 = _rtmp376.etype;
+        _size72 = _rtmp376.size;
+        for (var _i77 = 0; _i77 < _size72; ++_i77)
         {
-          var elem70 = null;
-          elem70 = new crouton_thrift.Command();
-          elem70.read(input);
-          this.commands.push(elem70);
+          var elem78 = null;
+          elem78 = new crouton_thrift.Command();
+          elem78.read(input);
+          this.commands.push(elem78);
         }
         input.readListEnd();
       } else {
@@ -1390,18 +1415,18 @@ crouton_thrift.ReportResponse.prototype.read = false && function(input) {
       break;
       case 3:
       if (ftype == Thrift.Type.LIST) {
-        var _size71 = 0;
-        var _rtmp375;
+        var _size79 = 0;
+        var _rtmp383;
         this.errors = [];
-        var _etype74 = 0;
-        _rtmp375 = input.readListBegin();
-        _etype74 = _rtmp375.etype;
-        _size71 = _rtmp375.size;
-        for (var _i76 = 0; _i76 < _size71; ++_i76)
+        var _etype82 = 0;
+        _rtmp383 = input.readListBegin();
+        _etype82 = _rtmp383.etype;
+        _size79 = _rtmp383.size;
+        for (var _i84 = 0; _i84 < _size79; ++_i84)
         {
-          var elem77 = null;
-          elem77 = input.readString().value;
-          this.errors.push(elem77);
+          var elem85 = null;
+          elem85 = input.readString().value;
+          this.errors.push(elem85);
         }
         input.readListEnd();
       } else {
@@ -1422,12 +1447,12 @@ crouton_thrift.ReportResponse.prototype.write = false && function(output) {
   if (this.commands !== null && this.commands !== undefined) {
     output.writeFieldBegin('commands', Thrift.Type.LIST, 1);
     output.writeListBegin(Thrift.Type.STRUCT, this.commands.length);
-    for (var iter78 in this.commands)
+    for (var iter86 in this.commands)
     {
-      if (this.commands.hasOwnProperty(iter78))
+      if (this.commands.hasOwnProperty(iter86))
       {
-        iter78 = this.commands[iter78];
-        iter78.write(output);
+        iter86 = this.commands[iter86];
+        iter86.write(output);
       }
     }
     output.writeListEnd();
@@ -1441,12 +1466,12 @@ crouton_thrift.ReportResponse.prototype.write = false && function(output) {
   if (this.errors !== null && this.errors !== undefined) {
     output.writeFieldBegin('errors', Thrift.Type.LIST, 3);
     output.writeListBegin(Thrift.Type.STRING, this.errors.length);
-    for (var iter79 in this.errors)
+    for (var iter87 in this.errors)
     {
-      if (this.errors.hasOwnProperty(iter79))
+      if (this.errors.hasOwnProperty(iter87))
       {
-        iter79 = this.errors[iter79];
-        output.writeString(iter79);
+        iter87 = this.errors[iter87];
+        output.writeString(iter87);
       }
     }
     output.writeListEnd();

--- a/src/imp/platform/browser/options_parser.js
+++ b/src/imp/platform/browser/options_parser.js
@@ -75,13 +75,9 @@ module.exports.parseScriptElementOptions = function (opts, browserOpts) {
             opts.enable = false;
         }
     }
-    let debug = dataset.debug;
-    if (typeof debug === 'string' && debug === 'true') {
-        opts.debug = true;
-    }
-    let verbose = dataset.verbose;
-    if (typeof verbose === 'string') {
-        opts.verbose = parseInt(verbose, 10);
+    let verbosity = dataset.verbosity;
+    if (typeof verbosity === 'string') {
+        opts.verbosity = parseInt(verbosity, 10);
     }
 
     let init = dataset.init_global_tracer;
@@ -114,12 +110,9 @@ module.exports.parseURLQueryOptions = function (opts) {
     }
 
     let params = urlQueryParameters();
-    if (params.lightstep_debug) {
-        opts.debug = true;
-    }
-    if (params.lightstep_verbose) {
+    if (params.lightstep_verbosity) {
         try {
-            opts.verbose = parseInt(params.lightstep_verbose, 10);
+            opts.verbosity = parseInt(params.lightstep_verbosity, 10);
         } catch (_ignored) { /* Ignored */ }
     }
     if (params.lightstep_log_to_console) {

--- a/src/imp/platform/browser/thrift_api/crouton_types.js
+++ b/src/imp/platform/browser/thrift_api/crouton_types.js
@@ -78,6 +78,76 @@ crouton_thrift.KeyValue.prototype.write = function(output) {
   return;
 };
 
+crouton_thrift.NamedCounter = function(args) {
+  this.Name = null;
+  this.Value = null;
+  if (args) {
+    if (args.Name !== undefined) {
+      this.Name = args.Name;
+    } else {
+      throw new Thrift.TProtocolException(Thrift.TProtocolExceptionType.UNKNOWN, 'Required field Name is unset!');
+    }
+    if (args.Value !== undefined) {
+      this.Value = args.Value;
+    } else {
+      throw new Thrift.TProtocolException(Thrift.TProtocolExceptionType.UNKNOWN, 'Required field Value is unset!');
+    }
+  }
+};
+crouton_thrift.NamedCounter.prototype = {};
+crouton_thrift.NamedCounter.prototype.read = function(input) {
+  input.readStructBegin();
+  while (true)
+  {
+    var ret = input.readFieldBegin();
+    var fname = ret.fname;
+    var ftype = ret.ftype;
+    var fid = ret.fid;
+    if (ftype == Thrift.Type.STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+      if (ftype == Thrift.Type.STRING) {
+        this.Name = input.readString().value;
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 2:
+      if (ftype == Thrift.Type.I64) {
+        this.Value = input.readI64().value;
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      default:
+        input.skip(ftype);
+    }
+    input.readFieldEnd();
+  }
+  input.readStructEnd();
+  return;
+};
+
+crouton_thrift.NamedCounter.prototype.write = function(output) {
+  output.writeStructBegin('NamedCounter');
+  if (this.Name !== null && this.Name !== undefined) {
+    output.writeFieldBegin('Name', Thrift.Type.STRING, 1);
+    output.writeString(this.Name);
+    output.writeFieldEnd();
+  }
+  if (this.Value !== null && this.Value !== undefined) {
+    output.writeFieldBegin('Value', Thrift.Type.I64, 2);
+    output.writeI64(this.Value);
+    output.writeFieldEnd();
+  }
+  output.writeFieldStop();
+  output.writeStructEnd();
+  return;
+};
+
 crouton_thrift.Runtime = function(args) {
   this.guid = null;
   this.start_micros = null;
@@ -899,6 +969,88 @@ crouton_thrift.Timing.prototype.write = function(output) {
   return;
 };
 
+crouton_thrift.SampleCount = function(args) {
+  this.oldest_micros = null;
+  this.youngest_micros = null;
+  this.count = null;
+  if (args) {
+    if (args.oldest_micros !== undefined) {
+      this.oldest_micros = args.oldest_micros;
+    }
+    if (args.youngest_micros !== undefined) {
+      this.youngest_micros = args.youngest_micros;
+    }
+    if (args.count !== undefined) {
+      this.count = args.count;
+    }
+  }
+};
+crouton_thrift.SampleCount.prototype = {};
+crouton_thrift.SampleCount.prototype.read = function(input) {
+  input.readStructBegin();
+  while (true)
+  {
+    var ret = input.readFieldBegin();
+    var fname = ret.fname;
+    var ftype = ret.ftype;
+    var fid = ret.fid;
+    if (ftype == Thrift.Type.STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+      if (ftype == Thrift.Type.I64) {
+        this.oldest_micros = input.readI64().value;
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 2:
+      if (ftype == Thrift.Type.I64) {
+        this.youngest_micros = input.readI64().value;
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 3:
+      if (ftype == Thrift.Type.I64) {
+        this.count = input.readI64().value;
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      default:
+        input.skip(ftype);
+    }
+    input.readFieldEnd();
+  }
+  input.readStructEnd();
+  return;
+};
+
+crouton_thrift.SampleCount.prototype.write = function(output) {
+  output.writeStructBegin('SampleCount');
+  if (this.oldest_micros !== null && this.oldest_micros !== undefined) {
+    output.writeFieldBegin('oldest_micros', Thrift.Type.I64, 1);
+    output.writeI64(this.oldest_micros);
+    output.writeFieldEnd();
+  }
+  if (this.youngest_micros !== null && this.youngest_micros !== undefined) {
+    output.writeFieldBegin('youngest_micros', Thrift.Type.I64, 2);
+    output.writeI64(this.youngest_micros);
+    output.writeFieldEnd();
+  }
+  if (this.count !== null && this.count !== undefined) {
+    output.writeFieldBegin('count', Thrift.Type.I64, 3);
+    output.writeI64(this.count);
+    output.writeFieldEnd();
+  }
+  output.writeFieldStop();
+  output.writeStructEnd();
+  return;
+};
+
 crouton_thrift.MetricsSample = function(args) {
   this.name = null;
   this.int64_value = null;
@@ -1066,6 +1218,7 @@ crouton_thrift.ReportRequest = function(args) {
   this.timestamp_offset_micros = null;
   this.oldest_micros = null;
   this.youngest_micros = null;
+  this.counters = null;
   this.internal_logs = null;
   this.internal_metrics = null;
   if (args) {
@@ -1086,6 +1239,9 @@ crouton_thrift.ReportRequest = function(args) {
     }
     if (args.youngest_micros !== undefined) {
       this.youngest_micros = args.youngest_micros;
+    }
+    if (args.counters !== undefined) {
+      this.counters = args.counters;
     }
     if (args.internal_logs !== undefined) {
       this.internal_logs = args.internal_logs;
@@ -1180,11 +1336,11 @@ crouton_thrift.ReportRequest.prototype.read = function(input) {
         input.skip(ftype);
       }
       break;
-      case 10:
+      case 9:
       if (ftype == Thrift.Type.LIST) {
         var _size62 = 0;
         var _rtmp366;
-        this.internal_logs = [];
+        this.counters = [];
         var _etype65 = 0;
         _rtmp366 = input.readListBegin();
         _etype65 = _rtmp366.etype;
@@ -1192,9 +1348,30 @@ crouton_thrift.ReportRequest.prototype.read = function(input) {
         for (var _i67 = 0; _i67 < _size62; ++_i67)
         {
           var elem68 = null;
-          elem68 = new crouton_thrift.LogRecord();
+          elem68 = new crouton_thrift.NamedCounter();
           elem68.read(input);
-          this.internal_logs.push(elem68);
+          this.counters.push(elem68);
+        }
+        input.readListEnd();
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 10:
+      if (ftype == Thrift.Type.LIST) {
+        var _size69 = 0;
+        var _rtmp373;
+        this.internal_logs = [];
+        var _etype72 = 0;
+        _rtmp373 = input.readListBegin();
+        _etype72 = _rtmp373.etype;
+        _size69 = _rtmp373.size;
+        for (var _i74 = 0; _i74 < _size69; ++_i74)
+        {
+          var elem75 = null;
+          elem75 = new crouton_thrift.LogRecord();
+          elem75.read(input);
+          this.internal_logs.push(elem75);
         }
         input.readListEnd();
       } else {
@@ -1228,12 +1405,12 @@ crouton_thrift.ReportRequest.prototype.write = function(output) {
   if (this.span_records !== null && this.span_records !== undefined) {
     output.writeFieldBegin('span_records', Thrift.Type.LIST, 3);
     output.writeListBegin(Thrift.Type.STRUCT, this.span_records.length);
-    for (var iter69 in this.span_records)
+    for (var iter76 in this.span_records)
     {
-      if (this.span_records.hasOwnProperty(iter69))
+      if (this.span_records.hasOwnProperty(iter76))
       {
-        iter69 = this.span_records[iter69];
-        iter69.write(output);
+        iter76 = this.span_records[iter76];
+        iter76.write(output);
       }
     }
     output.writeListEnd();
@@ -1242,12 +1419,12 @@ crouton_thrift.ReportRequest.prototype.write = function(output) {
   if (this.log_records !== null && this.log_records !== undefined) {
     output.writeFieldBegin('log_records', Thrift.Type.LIST, 4);
     output.writeListBegin(Thrift.Type.STRUCT, this.log_records.length);
-    for (var iter70 in this.log_records)
+    for (var iter77 in this.log_records)
     {
-      if (this.log_records.hasOwnProperty(iter70))
+      if (this.log_records.hasOwnProperty(iter77))
       {
-        iter70 = this.log_records[iter70];
-        iter70.write(output);
+        iter77 = this.log_records[iter77];
+        iter77.write(output);
       }
     }
     output.writeListEnd();
@@ -1268,15 +1445,29 @@ crouton_thrift.ReportRequest.prototype.write = function(output) {
     output.writeI64(this.youngest_micros);
     output.writeFieldEnd();
   }
+  if (this.counters !== null && this.counters !== undefined) {
+    output.writeFieldBegin('counters', Thrift.Type.LIST, 9);
+    output.writeListBegin(Thrift.Type.STRUCT, this.counters.length);
+    for (var iter78 in this.counters)
+    {
+      if (this.counters.hasOwnProperty(iter78))
+      {
+        iter78 = this.counters[iter78];
+        iter78.write(output);
+      }
+    }
+    output.writeListEnd();
+    output.writeFieldEnd();
+  }
   if (this.internal_logs !== null && this.internal_logs !== undefined) {
     output.writeFieldBegin('internal_logs', Thrift.Type.LIST, 10);
     output.writeListBegin(Thrift.Type.STRUCT, this.internal_logs.length);
-    for (var iter71 in this.internal_logs)
+    for (var iter79 in this.internal_logs)
     {
-      if (this.internal_logs.hasOwnProperty(iter71))
+      if (this.internal_logs.hasOwnProperty(iter79))
       {
-        iter71 = this.internal_logs[iter71];
-        iter71.write(output);
+        iter79 = this.internal_logs[iter79];
+        iter79.write(output);
       }
     }
     output.writeListEnd();
@@ -1377,19 +1568,19 @@ crouton_thrift.ReportResponse.prototype.read = function(input) {
     {
       case 1:
       if (ftype == Thrift.Type.LIST) {
-        var _size72 = 0;
-        var _rtmp376;
+        var _size80 = 0;
+        var _rtmp384;
         this.commands = [];
-        var _etype75 = 0;
-        _rtmp376 = input.readListBegin();
-        _etype75 = _rtmp376.etype;
-        _size72 = _rtmp376.size;
-        for (var _i77 = 0; _i77 < _size72; ++_i77)
+        var _etype83 = 0;
+        _rtmp384 = input.readListBegin();
+        _etype83 = _rtmp384.etype;
+        _size80 = _rtmp384.size;
+        for (var _i85 = 0; _i85 < _size80; ++_i85)
         {
-          var elem78 = null;
-          elem78 = new crouton_thrift.Command();
-          elem78.read(input);
-          this.commands.push(elem78);
+          var elem86 = null;
+          elem86 = new crouton_thrift.Command();
+          elem86.read(input);
+          this.commands.push(elem86);
         }
         input.readListEnd();
       } else {
@@ -1406,18 +1597,18 @@ crouton_thrift.ReportResponse.prototype.read = function(input) {
       break;
       case 3:
       if (ftype == Thrift.Type.LIST) {
-        var _size79 = 0;
-        var _rtmp383;
+        var _size87 = 0;
+        var _rtmp391;
         this.errors = [];
-        var _etype82 = 0;
-        _rtmp383 = input.readListBegin();
-        _etype82 = _rtmp383.etype;
-        _size79 = _rtmp383.size;
-        for (var _i84 = 0; _i84 < _size79; ++_i84)
+        var _etype90 = 0;
+        _rtmp391 = input.readListBegin();
+        _etype90 = _rtmp391.etype;
+        _size87 = _rtmp391.size;
+        for (var _i92 = 0; _i92 < _size87; ++_i92)
         {
-          var elem85 = null;
-          elem85 = input.readString().value;
-          this.errors.push(elem85);
+          var elem93 = null;
+          elem93 = input.readString().value;
+          this.errors.push(elem93);
         }
         input.readListEnd();
       } else {
@@ -1438,12 +1629,12 @@ crouton_thrift.ReportResponse.prototype.write = function(output) {
   if (this.commands !== null && this.commands !== undefined) {
     output.writeFieldBegin('commands', Thrift.Type.LIST, 1);
     output.writeListBegin(Thrift.Type.STRUCT, this.commands.length);
-    for (var iter86 in this.commands)
+    for (var iter94 in this.commands)
     {
-      if (this.commands.hasOwnProperty(iter86))
+      if (this.commands.hasOwnProperty(iter94))
       {
-        iter86 = this.commands[iter86];
-        iter86.write(output);
+        iter94 = this.commands[iter94];
+        iter94.write(output);
       }
     }
     output.writeListEnd();
@@ -1457,12 +1648,12 @@ crouton_thrift.ReportResponse.prototype.write = function(output) {
   if (this.errors !== null && this.errors !== undefined) {
     output.writeFieldBegin('errors', Thrift.Type.LIST, 3);
     output.writeListBegin(Thrift.Type.STRING, this.errors.length);
-    for (var iter87 in this.errors)
+    for (var iter95 in this.errors)
     {
-      if (this.errors.hasOwnProperty(iter87))
+      if (this.errors.hasOwnProperty(iter95))
       {
-        iter87 = this.errors[iter87];
-        output.writeString(iter87);
+        iter95 = this.errors[iter95];
+        output.writeString(iter95);
       }
     }
     output.writeListEnd();

--- a/src/imp/platform/browser/thrift_api/crouton_types.js
+++ b/src/imp/platform/browser/thrift_api/crouton_types.js
@@ -78,76 +78,6 @@ crouton_thrift.KeyValue.prototype.write = function(output) {
   return;
 };
 
-crouton_thrift.NamedCounter = function(args) {
-  this.Name = null;
-  this.Value = null;
-  if (args) {
-    if (args.Name !== undefined) {
-      this.Name = args.Name;
-    } else {
-      throw new Thrift.TProtocolException(Thrift.TProtocolExceptionType.UNKNOWN, 'Required field Name is unset!');
-    }
-    if (args.Value !== undefined) {
-      this.Value = args.Value;
-    } else {
-      throw new Thrift.TProtocolException(Thrift.TProtocolExceptionType.UNKNOWN, 'Required field Value is unset!');
-    }
-  }
-};
-crouton_thrift.NamedCounter.prototype = {};
-crouton_thrift.NamedCounter.prototype.read = function(input) {
-  input.readStructBegin();
-  while (true)
-  {
-    var ret = input.readFieldBegin();
-    var fname = ret.fname;
-    var ftype = ret.ftype;
-    var fid = ret.fid;
-    if (ftype == Thrift.Type.STOP) {
-      break;
-    }
-    switch (fid)
-    {
-      case 1:
-      if (ftype == Thrift.Type.STRING) {
-        this.Name = input.readString().value;
-      } else {
-        input.skip(ftype);
-      }
-      break;
-      case 2:
-      if (ftype == Thrift.Type.I64) {
-        this.Value = input.readI64().value;
-      } else {
-        input.skip(ftype);
-      }
-      break;
-      default:
-        input.skip(ftype);
-    }
-    input.readFieldEnd();
-  }
-  input.readStructEnd();
-  return;
-};
-
-crouton_thrift.NamedCounter.prototype.write = function(output) {
-  output.writeStructBegin('NamedCounter');
-  if (this.Name !== null && this.Name !== undefined) {
-    output.writeFieldBegin('Name', Thrift.Type.STRING, 1);
-    output.writeString(this.Name);
-    output.writeFieldEnd();
-  }
-  if (this.Value !== null && this.Value !== undefined) {
-    output.writeFieldBegin('Value', Thrift.Type.I64, 2);
-    output.writeI64(this.Value);
-    output.writeFieldEnd();
-  }
-  output.writeFieldStop();
-  output.writeStructEnd();
-  return;
-};
-
 crouton_thrift.Runtime = function(args) {
   this.guid = null;
   this.start_micros = null;
@@ -969,24 +899,26 @@ crouton_thrift.Timing.prototype.write = function(output) {
   return;
 };
 
-crouton_thrift.SampleCount = function(args) {
-  this.oldest_micros = null;
-  this.youngest_micros = null;
-  this.count = null;
+crouton_thrift.MetricsSample = function(args) {
+  this.name = null;
+  this.int64_value = null;
+  this.double_value = null;
   if (args) {
-    if (args.oldest_micros !== undefined) {
-      this.oldest_micros = args.oldest_micros;
+    if (args.name !== undefined) {
+      this.name = args.name;
+    } else {
+      throw new Thrift.TProtocolException(Thrift.TProtocolExceptionType.UNKNOWN, 'Required field name is unset!');
     }
-    if (args.youngest_micros !== undefined) {
-      this.youngest_micros = args.youngest_micros;
+    if (args.int64_value !== undefined) {
+      this.int64_value = args.int64_value;
     }
-    if (args.count !== undefined) {
-      this.count = args.count;
+    if (args.double_value !== undefined) {
+      this.double_value = args.double_value;
     }
   }
 };
-crouton_thrift.SampleCount.prototype = {};
-crouton_thrift.SampleCount.prototype.read = function(input) {
+crouton_thrift.MetricsSample.prototype = {};
+crouton_thrift.MetricsSample.prototype.read = function(input) {
   input.readStructBegin();
   while (true)
   {
@@ -1000,22 +932,22 @@ crouton_thrift.SampleCount.prototype.read = function(input) {
     switch (fid)
     {
       case 1:
-      if (ftype == Thrift.Type.I64) {
-        this.oldest_micros = input.readI64().value;
+      if (ftype == Thrift.Type.STRING) {
+        this.name = input.readString().value;
       } else {
         input.skip(ftype);
       }
       break;
       case 2:
       if (ftype == Thrift.Type.I64) {
-        this.youngest_micros = input.readI64().value;
+        this.int64_value = input.readI64().value;
       } else {
         input.skip(ftype);
       }
       break;
       case 3:
-      if (ftype == Thrift.Type.I64) {
-        this.count = input.readI64().value;
+      if (ftype == Thrift.Type.DOUBLE) {
+        this.double_value = input.readDouble().value;
       } else {
         input.skip(ftype);
       }
@@ -1029,21 +961,97 @@ crouton_thrift.SampleCount.prototype.read = function(input) {
   return;
 };
 
-crouton_thrift.SampleCount.prototype.write = function(output) {
-  output.writeStructBegin('SampleCount');
-  if (this.oldest_micros !== null && this.oldest_micros !== undefined) {
-    output.writeFieldBegin('oldest_micros', Thrift.Type.I64, 1);
-    output.writeI64(this.oldest_micros);
+crouton_thrift.MetricsSample.prototype.write = function(output) {
+  output.writeStructBegin('MetricsSample');
+  if (this.name !== null && this.name !== undefined) {
+    output.writeFieldBegin('name', Thrift.Type.STRING, 1);
+    output.writeString(this.name);
     output.writeFieldEnd();
   }
-  if (this.youngest_micros !== null && this.youngest_micros !== undefined) {
-    output.writeFieldBegin('youngest_micros', Thrift.Type.I64, 2);
-    output.writeI64(this.youngest_micros);
+  if (this.int64_value !== null && this.int64_value !== undefined) {
+    output.writeFieldBegin('int64_value', Thrift.Type.I64, 2);
+    output.writeI64(this.int64_value);
     output.writeFieldEnd();
   }
-  if (this.count !== null && this.count !== undefined) {
-    output.writeFieldBegin('count', Thrift.Type.I64, 3);
-    output.writeI64(this.count);
+  if (this.double_value !== null && this.double_value !== undefined) {
+    output.writeFieldBegin('double_value', Thrift.Type.DOUBLE, 3);
+    output.writeDouble(this.double_value);
+    output.writeFieldEnd();
+  }
+  output.writeFieldStop();
+  output.writeStructEnd();
+  return;
+};
+
+crouton_thrift.Metrics = function(args) {
+  this.counts = null;
+  if (args) {
+    if (args.counts !== undefined) {
+      this.counts = args.counts;
+    }
+  }
+};
+crouton_thrift.Metrics.prototype = {};
+crouton_thrift.Metrics.prototype.read = function(input) {
+  input.readStructBegin();
+  while (true)
+  {
+    var ret = input.readFieldBegin();
+    var fname = ret.fname;
+    var ftype = ret.ftype;
+    var fid = ret.fid;
+    if (ftype == Thrift.Type.STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+      if (ftype == Thrift.Type.LIST) {
+        var _size40 = 0;
+        var _rtmp344;
+        this.counts = [];
+        var _etype43 = 0;
+        _rtmp344 = input.readListBegin();
+        _etype43 = _rtmp344.etype;
+        _size40 = _rtmp344.size;
+        for (var _i45 = 0; _i45 < _size40; ++_i45)
+        {
+          var elem46 = null;
+          elem46 = new crouton_thrift.MetricsSample();
+          elem46.read(input);
+          this.counts.push(elem46);
+        }
+        input.readListEnd();
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 0:
+        input.skip(ftype);
+        break;
+      default:
+        input.skip(ftype);
+    }
+    input.readFieldEnd();
+  }
+  input.readStructEnd();
+  return;
+};
+
+crouton_thrift.Metrics.prototype.write = function(output) {
+  output.writeStructBegin('Metrics');
+  if (this.counts !== null && this.counts !== undefined) {
+    output.writeFieldBegin('counts', Thrift.Type.LIST, 1);
+    output.writeListBegin(Thrift.Type.STRUCT, this.counts.length);
+    for (var iter47 in this.counts)
+    {
+      if (this.counts.hasOwnProperty(iter47))
+      {
+        iter47 = this.counts[iter47];
+        iter47.write(output);
+      }
+    }
+    output.writeListEnd();
     output.writeFieldEnd();
   }
   output.writeFieldStop();
@@ -1058,7 +1066,8 @@ crouton_thrift.ReportRequest = function(args) {
   this.timestamp_offset_micros = null;
   this.oldest_micros = null;
   this.youngest_micros = null;
-  this.counters = null;
+  this.internal_logs = null;
+  this.internal_metrics = null;
   if (args) {
     if (args.runtime !== undefined) {
       this.runtime = args.runtime;
@@ -1078,8 +1087,11 @@ crouton_thrift.ReportRequest = function(args) {
     if (args.youngest_micros !== undefined) {
       this.youngest_micros = args.youngest_micros;
     }
-    if (args.counters !== undefined) {
-      this.counters = args.counters;
+    if (args.internal_logs !== undefined) {
+      this.internal_logs = args.internal_logs;
+    }
+    if (args.internal_metrics !== undefined) {
+      this.internal_metrics = args.internal_metrics;
     }
   }
 };
@@ -1107,19 +1119,19 @@ crouton_thrift.ReportRequest.prototype.read = function(input) {
       break;
       case 3:
       if (ftype == Thrift.Type.LIST) {
-        var _size40 = 0;
-        var _rtmp344;
+        var _size48 = 0;
+        var _rtmp352;
         this.span_records = [];
-        var _etype43 = 0;
-        _rtmp344 = input.readListBegin();
-        _etype43 = _rtmp344.etype;
-        _size40 = _rtmp344.size;
-        for (var _i45 = 0; _i45 < _size40; ++_i45)
+        var _etype51 = 0;
+        _rtmp352 = input.readListBegin();
+        _etype51 = _rtmp352.etype;
+        _size48 = _rtmp352.size;
+        for (var _i53 = 0; _i53 < _size48; ++_i53)
         {
-          var elem46 = null;
-          elem46 = new crouton_thrift.SpanRecord();
-          elem46.read(input);
-          this.span_records.push(elem46);
+          var elem54 = null;
+          elem54 = new crouton_thrift.SpanRecord();
+          elem54.read(input);
+          this.span_records.push(elem54);
         }
         input.readListEnd();
       } else {
@@ -1128,19 +1140,19 @@ crouton_thrift.ReportRequest.prototype.read = function(input) {
       break;
       case 4:
       if (ftype == Thrift.Type.LIST) {
-        var _size47 = 0;
-        var _rtmp351;
+        var _size55 = 0;
+        var _rtmp359;
         this.log_records = [];
-        var _etype50 = 0;
-        _rtmp351 = input.readListBegin();
-        _etype50 = _rtmp351.etype;
-        _size47 = _rtmp351.size;
-        for (var _i52 = 0; _i52 < _size47; ++_i52)
+        var _etype58 = 0;
+        _rtmp359 = input.readListBegin();
+        _etype58 = _rtmp359.etype;
+        _size55 = _rtmp359.size;
+        for (var _i60 = 0; _i60 < _size55; ++_i60)
         {
-          var elem53 = null;
-          elem53 = new crouton_thrift.LogRecord();
-          elem53.read(input);
-          this.log_records.push(elem53);
+          var elem61 = null;
+          elem61 = new crouton_thrift.LogRecord();
+          elem61.read(input);
+          this.log_records.push(elem61);
         }
         input.readListEnd();
       } else {
@@ -1168,23 +1180,31 @@ crouton_thrift.ReportRequest.prototype.read = function(input) {
         input.skip(ftype);
       }
       break;
-      case 9:
+      case 10:
       if (ftype == Thrift.Type.LIST) {
-        var _size54 = 0;
-        var _rtmp358;
-        this.counters = [];
-        var _etype57 = 0;
-        _rtmp358 = input.readListBegin();
-        _etype57 = _rtmp358.etype;
-        _size54 = _rtmp358.size;
-        for (var _i59 = 0; _i59 < _size54; ++_i59)
+        var _size62 = 0;
+        var _rtmp366;
+        this.internal_logs = [];
+        var _etype65 = 0;
+        _rtmp366 = input.readListBegin();
+        _etype65 = _rtmp366.etype;
+        _size62 = _rtmp366.size;
+        for (var _i67 = 0; _i67 < _size62; ++_i67)
         {
-          var elem60 = null;
-          elem60 = new crouton_thrift.NamedCounter();
-          elem60.read(input);
-          this.counters.push(elem60);
+          var elem68 = null;
+          elem68 = new crouton_thrift.LogRecord();
+          elem68.read(input);
+          this.internal_logs.push(elem68);
         }
         input.readListEnd();
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 11:
+      if (ftype == Thrift.Type.STRUCT) {
+        this.internal_metrics = new crouton_thrift.Metrics();
+        this.internal_metrics.read(input);
       } else {
         input.skip(ftype);
       }
@@ -1208,12 +1228,12 @@ crouton_thrift.ReportRequest.prototype.write = function(output) {
   if (this.span_records !== null && this.span_records !== undefined) {
     output.writeFieldBegin('span_records', Thrift.Type.LIST, 3);
     output.writeListBegin(Thrift.Type.STRUCT, this.span_records.length);
-    for (var iter61 in this.span_records)
+    for (var iter69 in this.span_records)
     {
-      if (this.span_records.hasOwnProperty(iter61))
+      if (this.span_records.hasOwnProperty(iter69))
       {
-        iter61 = this.span_records[iter61];
-        iter61.write(output);
+        iter69 = this.span_records[iter69];
+        iter69.write(output);
       }
     }
     output.writeListEnd();
@@ -1222,12 +1242,12 @@ crouton_thrift.ReportRequest.prototype.write = function(output) {
   if (this.log_records !== null && this.log_records !== undefined) {
     output.writeFieldBegin('log_records', Thrift.Type.LIST, 4);
     output.writeListBegin(Thrift.Type.STRUCT, this.log_records.length);
-    for (var iter62 in this.log_records)
+    for (var iter70 in this.log_records)
     {
-      if (this.log_records.hasOwnProperty(iter62))
+      if (this.log_records.hasOwnProperty(iter70))
       {
-        iter62 = this.log_records[iter62];
-        iter62.write(output);
+        iter70 = this.log_records[iter70];
+        iter70.write(output);
       }
     }
     output.writeListEnd();
@@ -1248,18 +1268,23 @@ crouton_thrift.ReportRequest.prototype.write = function(output) {
     output.writeI64(this.youngest_micros);
     output.writeFieldEnd();
   }
-  if (this.counters !== null && this.counters !== undefined) {
-    output.writeFieldBegin('counters', Thrift.Type.LIST, 9);
-    output.writeListBegin(Thrift.Type.STRUCT, this.counters.length);
-    for (var iter63 in this.counters)
+  if (this.internal_logs !== null && this.internal_logs !== undefined) {
+    output.writeFieldBegin('internal_logs', Thrift.Type.LIST, 10);
+    output.writeListBegin(Thrift.Type.STRUCT, this.internal_logs.length);
+    for (var iter71 in this.internal_logs)
     {
-      if (this.counters.hasOwnProperty(iter63))
+      if (this.internal_logs.hasOwnProperty(iter71))
       {
-        iter63 = this.counters[iter63];
-        iter63.write(output);
+        iter71 = this.internal_logs[iter71];
+        iter71.write(output);
       }
     }
     output.writeListEnd();
+    output.writeFieldEnd();
+  }
+  if (this.internal_metrics !== null && this.internal_metrics !== undefined) {
+    output.writeFieldBegin('internal_metrics', Thrift.Type.STRUCT, 11);
+    this.internal_metrics.write(output);
     output.writeFieldEnd();
   }
   output.writeFieldStop();
@@ -1352,19 +1377,19 @@ crouton_thrift.ReportResponse.prototype.read = function(input) {
     {
       case 1:
       if (ftype == Thrift.Type.LIST) {
-        var _size64 = 0;
-        var _rtmp368;
+        var _size72 = 0;
+        var _rtmp376;
         this.commands = [];
-        var _etype67 = 0;
-        _rtmp368 = input.readListBegin();
-        _etype67 = _rtmp368.etype;
-        _size64 = _rtmp368.size;
-        for (var _i69 = 0; _i69 < _size64; ++_i69)
+        var _etype75 = 0;
+        _rtmp376 = input.readListBegin();
+        _etype75 = _rtmp376.etype;
+        _size72 = _rtmp376.size;
+        for (var _i77 = 0; _i77 < _size72; ++_i77)
         {
-          var elem70 = null;
-          elem70 = new crouton_thrift.Command();
-          elem70.read(input);
-          this.commands.push(elem70);
+          var elem78 = null;
+          elem78 = new crouton_thrift.Command();
+          elem78.read(input);
+          this.commands.push(elem78);
         }
         input.readListEnd();
       } else {
@@ -1381,18 +1406,18 @@ crouton_thrift.ReportResponse.prototype.read = function(input) {
       break;
       case 3:
       if (ftype == Thrift.Type.LIST) {
-        var _size71 = 0;
-        var _rtmp375;
+        var _size79 = 0;
+        var _rtmp383;
         this.errors = [];
-        var _etype74 = 0;
-        _rtmp375 = input.readListBegin();
-        _etype74 = _rtmp375.etype;
-        _size71 = _rtmp375.size;
-        for (var _i76 = 0; _i76 < _size71; ++_i76)
+        var _etype82 = 0;
+        _rtmp383 = input.readListBegin();
+        _etype82 = _rtmp383.etype;
+        _size79 = _rtmp383.size;
+        for (var _i84 = 0; _i84 < _size79; ++_i84)
         {
-          var elem77 = null;
-          elem77 = input.readString().value;
-          this.errors.push(elem77);
+          var elem85 = null;
+          elem85 = input.readString().value;
+          this.errors.push(elem85);
         }
         input.readListEnd();
       } else {
@@ -1413,12 +1438,12 @@ crouton_thrift.ReportResponse.prototype.write = function(output) {
   if (this.commands !== null && this.commands !== undefined) {
     output.writeFieldBegin('commands', Thrift.Type.LIST, 1);
     output.writeListBegin(Thrift.Type.STRUCT, this.commands.length);
-    for (var iter78 in this.commands)
+    for (var iter86 in this.commands)
     {
-      if (this.commands.hasOwnProperty(iter78))
+      if (this.commands.hasOwnProperty(iter86))
       {
-        iter78 = this.commands[iter78];
-        iter78.write(output);
+        iter86 = this.commands[iter86];
+        iter86.write(output);
       }
     }
     output.writeListEnd();
@@ -1432,12 +1457,12 @@ crouton_thrift.ReportResponse.prototype.write = function(output) {
   if (this.errors !== null && this.errors !== undefined) {
     output.writeFieldBegin('errors', Thrift.Type.LIST, 3);
     output.writeListBegin(Thrift.Type.STRING, this.errors.length);
-    for (var iter79 in this.errors)
+    for (var iter87 in this.errors)
     {
-      if (this.errors.hasOwnProperty(iter79))
+      if (this.errors.hasOwnProperty(iter87))
       {
-        iter79 = this.errors[iter79];
-        output.writeString(iter79);
+        iter87 = this.errors[iter87];
+        output.writeString(iter87);
       }
     }
     output.writeListEnd();

--- a/src/imp/platform/node/generated/crouton_types.js
+++ b/src/imp/platform/node/generated/crouton_types.js
@@ -84,76 +84,6 @@ crouton_thrift.KeyValue.prototype.write = function(output) {
   return;
 };
 
-crouton_thrift.NamedCounter = module.exports.NamedCounter = function(args) {
-  this.Name = null;
-  this.Value = null;
-  if (args) {
-    if (args.Name !== undefined) {
-      this.Name = args.Name;
-    } else {
-      throw new Thrift.TProtocolException(Thrift.TProtocolExceptionType.UNKNOWN, 'Required field Name is unset!');
-    }
-    if (args.Value !== undefined) {
-      this.Value = args.Value;
-    } else {
-      throw new Thrift.TProtocolException(Thrift.TProtocolExceptionType.UNKNOWN, 'Required field Value is unset!');
-    }
-  }
-};
-crouton_thrift.NamedCounter.prototype = {};
-crouton_thrift.NamedCounter.prototype.read = function(input) {
-  input.readStructBegin();
-  while (true)
-  {
-    var ret = input.readFieldBegin();
-    var fname = ret.fname;
-    var ftype = ret.ftype;
-    var fid = ret.fid;
-    if (ftype == Thrift.Type.STOP) {
-      break;
-    }
-    switch (fid)
-    {
-      case 1:
-      if (ftype == Thrift.Type.STRING) {
-        this.Name = input.readString();
-      } else {
-        input.skip(ftype);
-      }
-      break;
-      case 2:
-      if (ftype == Thrift.Type.I64) {
-        this.Value = input.readI64();
-      } else {
-        input.skip(ftype);
-      }
-      break;
-      default:
-        input.skip(ftype);
-    }
-    input.readFieldEnd();
-  }
-  input.readStructEnd();
-  return;
-};
-
-crouton_thrift.NamedCounter.prototype.write = function(output) {
-  output.writeStructBegin('NamedCounter');
-  if (this.Name !== null && this.Name !== undefined) {
-    output.writeFieldBegin('Name', Thrift.Type.STRING, 1);
-    output.writeString(this.Name);
-    output.writeFieldEnd();
-  }
-  if (this.Value !== null && this.Value !== undefined) {
-    output.writeFieldBegin('Value', Thrift.Type.I64, 2);
-    output.writeI64(this.Value);
-    output.writeFieldEnd();
-  }
-  output.writeFieldStop();
-  output.writeStructEnd();
-  return;
-};
-
 crouton_thrift.Runtime = module.exports.Runtime = function(args) {
   this.guid = null;
   this.start_micros = null;
@@ -975,24 +905,26 @@ crouton_thrift.Timing.prototype.write = function(output) {
   return;
 };
 
-crouton_thrift.SampleCount = module.exports.SampleCount = function(args) {
-  this.oldest_micros = null;
-  this.youngest_micros = null;
-  this.count = null;
+crouton_thrift.MetricsSample = module.exports.MetricsSample = function(args) {
+  this.name = null;
+  this.int64_value = null;
+  this.double_value = null;
   if (args) {
-    if (args.oldest_micros !== undefined) {
-      this.oldest_micros = args.oldest_micros;
+    if (args.name !== undefined) {
+      this.name = args.name;
+    } else {
+      throw new Thrift.TProtocolException(Thrift.TProtocolExceptionType.UNKNOWN, 'Required field name is unset!');
     }
-    if (args.youngest_micros !== undefined) {
-      this.youngest_micros = args.youngest_micros;
+    if (args.int64_value !== undefined) {
+      this.int64_value = args.int64_value;
     }
-    if (args.count !== undefined) {
-      this.count = args.count;
+    if (args.double_value !== undefined) {
+      this.double_value = args.double_value;
     }
   }
 };
-crouton_thrift.SampleCount.prototype = {};
-crouton_thrift.SampleCount.prototype.read = function(input) {
+crouton_thrift.MetricsSample.prototype = {};
+crouton_thrift.MetricsSample.prototype.read = function(input) {
   input.readStructBegin();
   while (true)
   {
@@ -1006,22 +938,22 @@ crouton_thrift.SampleCount.prototype.read = function(input) {
     switch (fid)
     {
       case 1:
-      if (ftype == Thrift.Type.I64) {
-        this.oldest_micros = input.readI64();
+      if (ftype == Thrift.Type.STRING) {
+        this.name = input.readString();
       } else {
         input.skip(ftype);
       }
       break;
       case 2:
       if (ftype == Thrift.Type.I64) {
-        this.youngest_micros = input.readI64();
+        this.int64_value = input.readI64();
       } else {
         input.skip(ftype);
       }
       break;
       case 3:
-      if (ftype == Thrift.Type.I64) {
-        this.count = input.readI64();
+      if (ftype == Thrift.Type.DOUBLE) {
+        this.double_value = input.readDouble();
       } else {
         input.skip(ftype);
       }
@@ -1035,21 +967,97 @@ crouton_thrift.SampleCount.prototype.read = function(input) {
   return;
 };
 
-crouton_thrift.SampleCount.prototype.write = function(output) {
-  output.writeStructBegin('SampleCount');
-  if (this.oldest_micros !== null && this.oldest_micros !== undefined) {
-    output.writeFieldBegin('oldest_micros', Thrift.Type.I64, 1);
-    output.writeI64(this.oldest_micros);
+crouton_thrift.MetricsSample.prototype.write = function(output) {
+  output.writeStructBegin('MetricsSample');
+  if (this.name !== null && this.name !== undefined) {
+    output.writeFieldBegin('name', Thrift.Type.STRING, 1);
+    output.writeString(this.name);
     output.writeFieldEnd();
   }
-  if (this.youngest_micros !== null && this.youngest_micros !== undefined) {
-    output.writeFieldBegin('youngest_micros', Thrift.Type.I64, 2);
-    output.writeI64(this.youngest_micros);
+  if (this.int64_value !== null && this.int64_value !== undefined) {
+    output.writeFieldBegin('int64_value', Thrift.Type.I64, 2);
+    output.writeI64(this.int64_value);
     output.writeFieldEnd();
   }
-  if (this.count !== null && this.count !== undefined) {
-    output.writeFieldBegin('count', Thrift.Type.I64, 3);
-    output.writeI64(this.count);
+  if (this.double_value !== null && this.double_value !== undefined) {
+    output.writeFieldBegin('double_value', Thrift.Type.DOUBLE, 3);
+    output.writeDouble(this.double_value);
+    output.writeFieldEnd();
+  }
+  output.writeFieldStop();
+  output.writeStructEnd();
+  return;
+};
+
+crouton_thrift.Metrics = module.exports.Metrics = function(args) {
+  this.counts = null;
+  if (args) {
+    if (args.counts !== undefined) {
+      this.counts = args.counts;
+    }
+  }
+};
+crouton_thrift.Metrics.prototype = {};
+crouton_thrift.Metrics.prototype.read = function(input) {
+  input.readStructBegin();
+  while (true)
+  {
+    var ret = input.readFieldBegin();
+    var fname = ret.fname;
+    var ftype = ret.ftype;
+    var fid = ret.fid;
+    if (ftype == Thrift.Type.STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+      if (ftype == Thrift.Type.LIST) {
+        var _size40 = 0;
+        var _rtmp344;
+        this.counts = [];
+        var _etype43 = 0;
+        _rtmp344 = input.readListBegin();
+        _etype43 = _rtmp344.etype;
+        _size40 = _rtmp344.size;
+        for (var _i45 = 0; _i45 < _size40; ++_i45)
+        {
+          var elem46 = null;
+          elem46 = new ttypes.MetricsSample();
+          elem46.read(input);
+          this.counts.push(elem46);
+        }
+        input.readListEnd();
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 0:
+        input.skip(ftype);
+        break;
+      default:
+        input.skip(ftype);
+    }
+    input.readFieldEnd();
+  }
+  input.readStructEnd();
+  return;
+};
+
+crouton_thrift.Metrics.prototype.write = function(output) {
+  output.writeStructBegin('Metrics');
+  if (this.counts !== null && this.counts !== undefined) {
+    output.writeFieldBegin('counts', Thrift.Type.LIST, 1);
+    output.writeListBegin(Thrift.Type.STRUCT, this.counts.length);
+    for (var iter47 in this.counts)
+    {
+      if (this.counts.hasOwnProperty(iter47))
+      {
+        iter47 = this.counts[iter47];
+        iter47.write(output);
+      }
+    }
+    output.writeListEnd();
     output.writeFieldEnd();
   }
   output.writeFieldStop();
@@ -1064,7 +1072,8 @@ crouton_thrift.ReportRequest = module.exports.ReportRequest = function(args) {
   this.timestamp_offset_micros = null;
   this.oldest_micros = null;
   this.youngest_micros = null;
-  this.counters = null;
+  this.internal_logs = null;
+  this.internal_metrics = null;
   if (args) {
     if (args.runtime !== undefined) {
       this.runtime = args.runtime;
@@ -1084,8 +1093,11 @@ crouton_thrift.ReportRequest = module.exports.ReportRequest = function(args) {
     if (args.youngest_micros !== undefined) {
       this.youngest_micros = args.youngest_micros;
     }
-    if (args.counters !== undefined) {
-      this.counters = args.counters;
+    if (args.internal_logs !== undefined) {
+      this.internal_logs = args.internal_logs;
+    }
+    if (args.internal_metrics !== undefined) {
+      this.internal_metrics = args.internal_metrics;
     }
   }
 };
@@ -1113,19 +1125,19 @@ crouton_thrift.ReportRequest.prototype.read = function(input) {
       break;
       case 3:
       if (ftype == Thrift.Type.LIST) {
-        var _size40 = 0;
-        var _rtmp344;
+        var _size48 = 0;
+        var _rtmp352;
         this.span_records = [];
-        var _etype43 = 0;
-        _rtmp344 = input.readListBegin();
-        _etype43 = _rtmp344.etype;
-        _size40 = _rtmp344.size;
-        for (var _i45 = 0; _i45 < _size40; ++_i45)
+        var _etype51 = 0;
+        _rtmp352 = input.readListBegin();
+        _etype51 = _rtmp352.etype;
+        _size48 = _rtmp352.size;
+        for (var _i53 = 0; _i53 < _size48; ++_i53)
         {
-          var elem46 = null;
-          elem46 = new ttypes.SpanRecord();
-          elem46.read(input);
-          this.span_records.push(elem46);
+          var elem54 = null;
+          elem54 = new ttypes.SpanRecord();
+          elem54.read(input);
+          this.span_records.push(elem54);
         }
         input.readListEnd();
       } else {
@@ -1134,19 +1146,19 @@ crouton_thrift.ReportRequest.prototype.read = function(input) {
       break;
       case 4:
       if (ftype == Thrift.Type.LIST) {
-        var _size47 = 0;
-        var _rtmp351;
+        var _size55 = 0;
+        var _rtmp359;
         this.log_records = [];
-        var _etype50 = 0;
-        _rtmp351 = input.readListBegin();
-        _etype50 = _rtmp351.etype;
-        _size47 = _rtmp351.size;
-        for (var _i52 = 0; _i52 < _size47; ++_i52)
+        var _etype58 = 0;
+        _rtmp359 = input.readListBegin();
+        _etype58 = _rtmp359.etype;
+        _size55 = _rtmp359.size;
+        for (var _i60 = 0; _i60 < _size55; ++_i60)
         {
-          var elem53 = null;
-          elem53 = new ttypes.LogRecord();
-          elem53.read(input);
-          this.log_records.push(elem53);
+          var elem61 = null;
+          elem61 = new ttypes.LogRecord();
+          elem61.read(input);
+          this.log_records.push(elem61);
         }
         input.readListEnd();
       } else {
@@ -1174,23 +1186,31 @@ crouton_thrift.ReportRequest.prototype.read = function(input) {
         input.skip(ftype);
       }
       break;
-      case 9:
+      case 10:
       if (ftype == Thrift.Type.LIST) {
-        var _size54 = 0;
-        var _rtmp358;
-        this.counters = [];
-        var _etype57 = 0;
-        _rtmp358 = input.readListBegin();
-        _etype57 = _rtmp358.etype;
-        _size54 = _rtmp358.size;
-        for (var _i59 = 0; _i59 < _size54; ++_i59)
+        var _size62 = 0;
+        var _rtmp366;
+        this.internal_logs = [];
+        var _etype65 = 0;
+        _rtmp366 = input.readListBegin();
+        _etype65 = _rtmp366.etype;
+        _size62 = _rtmp366.size;
+        for (var _i67 = 0; _i67 < _size62; ++_i67)
         {
-          var elem60 = null;
-          elem60 = new ttypes.NamedCounter();
-          elem60.read(input);
-          this.counters.push(elem60);
+          var elem68 = null;
+          elem68 = new ttypes.LogRecord();
+          elem68.read(input);
+          this.internal_logs.push(elem68);
         }
         input.readListEnd();
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 11:
+      if (ftype == Thrift.Type.STRUCT) {
+        this.internal_metrics = new ttypes.Metrics();
+        this.internal_metrics.read(input);
       } else {
         input.skip(ftype);
       }
@@ -1214,12 +1234,12 @@ crouton_thrift.ReportRequest.prototype.write = function(output) {
   if (this.span_records !== null && this.span_records !== undefined) {
     output.writeFieldBegin('span_records', Thrift.Type.LIST, 3);
     output.writeListBegin(Thrift.Type.STRUCT, this.span_records.length);
-    for (var iter61 in this.span_records)
+    for (var iter69 in this.span_records)
     {
-      if (this.span_records.hasOwnProperty(iter61))
+      if (this.span_records.hasOwnProperty(iter69))
       {
-        iter61 = this.span_records[iter61];
-        iter61.write(output);
+        iter69 = this.span_records[iter69];
+        iter69.write(output);
       }
     }
     output.writeListEnd();
@@ -1228,12 +1248,12 @@ crouton_thrift.ReportRequest.prototype.write = function(output) {
   if (this.log_records !== null && this.log_records !== undefined) {
     output.writeFieldBegin('log_records', Thrift.Type.LIST, 4);
     output.writeListBegin(Thrift.Type.STRUCT, this.log_records.length);
-    for (var iter62 in this.log_records)
+    for (var iter70 in this.log_records)
     {
-      if (this.log_records.hasOwnProperty(iter62))
+      if (this.log_records.hasOwnProperty(iter70))
       {
-        iter62 = this.log_records[iter62];
-        iter62.write(output);
+        iter70 = this.log_records[iter70];
+        iter70.write(output);
       }
     }
     output.writeListEnd();
@@ -1254,18 +1274,23 @@ crouton_thrift.ReportRequest.prototype.write = function(output) {
     output.writeI64(this.youngest_micros);
     output.writeFieldEnd();
   }
-  if (this.counters !== null && this.counters !== undefined) {
-    output.writeFieldBegin('counters', Thrift.Type.LIST, 9);
-    output.writeListBegin(Thrift.Type.STRUCT, this.counters.length);
-    for (var iter63 in this.counters)
+  if (this.internal_logs !== null && this.internal_logs !== undefined) {
+    output.writeFieldBegin('internal_logs', Thrift.Type.LIST, 10);
+    output.writeListBegin(Thrift.Type.STRUCT, this.internal_logs.length);
+    for (var iter71 in this.internal_logs)
     {
-      if (this.counters.hasOwnProperty(iter63))
+      if (this.internal_logs.hasOwnProperty(iter71))
       {
-        iter63 = this.counters[iter63];
-        iter63.write(output);
+        iter71 = this.internal_logs[iter71];
+        iter71.write(output);
       }
     }
     output.writeListEnd();
+    output.writeFieldEnd();
+  }
+  if (this.internal_metrics !== null && this.internal_metrics !== undefined) {
+    output.writeFieldBegin('internal_metrics', Thrift.Type.STRUCT, 11);
+    this.internal_metrics.write(output);
     output.writeFieldEnd();
   }
   output.writeFieldStop();
@@ -1358,19 +1383,19 @@ crouton_thrift.ReportResponse.prototype.read = function(input) {
     {
       case 1:
       if (ftype == Thrift.Type.LIST) {
-        var _size64 = 0;
-        var _rtmp368;
+        var _size72 = 0;
+        var _rtmp376;
         this.commands = [];
-        var _etype67 = 0;
-        _rtmp368 = input.readListBegin();
-        _etype67 = _rtmp368.etype;
-        _size64 = _rtmp368.size;
-        for (var _i69 = 0; _i69 < _size64; ++_i69)
+        var _etype75 = 0;
+        _rtmp376 = input.readListBegin();
+        _etype75 = _rtmp376.etype;
+        _size72 = _rtmp376.size;
+        for (var _i77 = 0; _i77 < _size72; ++_i77)
         {
-          var elem70 = null;
-          elem70 = new ttypes.Command();
-          elem70.read(input);
-          this.commands.push(elem70);
+          var elem78 = null;
+          elem78 = new ttypes.Command();
+          elem78.read(input);
+          this.commands.push(elem78);
         }
         input.readListEnd();
       } else {
@@ -1387,18 +1412,18 @@ crouton_thrift.ReportResponse.prototype.read = function(input) {
       break;
       case 3:
       if (ftype == Thrift.Type.LIST) {
-        var _size71 = 0;
-        var _rtmp375;
+        var _size79 = 0;
+        var _rtmp383;
         this.errors = [];
-        var _etype74 = 0;
-        _rtmp375 = input.readListBegin();
-        _etype74 = _rtmp375.etype;
-        _size71 = _rtmp375.size;
-        for (var _i76 = 0; _i76 < _size71; ++_i76)
+        var _etype82 = 0;
+        _rtmp383 = input.readListBegin();
+        _etype82 = _rtmp383.etype;
+        _size79 = _rtmp383.size;
+        for (var _i84 = 0; _i84 < _size79; ++_i84)
         {
-          var elem77 = null;
-          elem77 = input.readString();
-          this.errors.push(elem77);
+          var elem85 = null;
+          elem85 = input.readString();
+          this.errors.push(elem85);
         }
         input.readListEnd();
       } else {
@@ -1419,12 +1444,12 @@ crouton_thrift.ReportResponse.prototype.write = function(output) {
   if (this.commands !== null && this.commands !== undefined) {
     output.writeFieldBegin('commands', Thrift.Type.LIST, 1);
     output.writeListBegin(Thrift.Type.STRUCT, this.commands.length);
-    for (var iter78 in this.commands)
+    for (var iter86 in this.commands)
     {
-      if (this.commands.hasOwnProperty(iter78))
+      if (this.commands.hasOwnProperty(iter86))
       {
-        iter78 = this.commands[iter78];
-        iter78.write(output);
+        iter86 = this.commands[iter86];
+        iter86.write(output);
       }
     }
     output.writeListEnd();
@@ -1438,12 +1463,12 @@ crouton_thrift.ReportResponse.prototype.write = function(output) {
   if (this.errors !== null && this.errors !== undefined) {
     output.writeFieldBegin('errors', Thrift.Type.LIST, 3);
     output.writeListBegin(Thrift.Type.STRING, this.errors.length);
-    for (var iter79 in this.errors)
+    for (var iter87 in this.errors)
     {
-      if (this.errors.hasOwnProperty(iter79))
+      if (this.errors.hasOwnProperty(iter87))
       {
-        iter79 = this.errors[iter79];
-        output.writeString(iter79);
+        iter87 = this.errors[iter87];
+        output.writeString(iter87);
       }
     }
     output.writeListEnd();

--- a/src/imp/platform/node/generated/crouton_types.js
+++ b/src/imp/platform/node/generated/crouton_types.js
@@ -84,6 +84,76 @@ crouton_thrift.KeyValue.prototype.write = function(output) {
   return;
 };
 
+crouton_thrift.NamedCounter = module.exports.NamedCounter = function(args) {
+  this.Name = null;
+  this.Value = null;
+  if (args) {
+    if (args.Name !== undefined) {
+      this.Name = args.Name;
+    } else {
+      throw new Thrift.TProtocolException(Thrift.TProtocolExceptionType.UNKNOWN, 'Required field Name is unset!');
+    }
+    if (args.Value !== undefined) {
+      this.Value = args.Value;
+    } else {
+      throw new Thrift.TProtocolException(Thrift.TProtocolExceptionType.UNKNOWN, 'Required field Value is unset!');
+    }
+  }
+};
+crouton_thrift.NamedCounter.prototype = {};
+crouton_thrift.NamedCounter.prototype.read = function(input) {
+  input.readStructBegin();
+  while (true)
+  {
+    var ret = input.readFieldBegin();
+    var fname = ret.fname;
+    var ftype = ret.ftype;
+    var fid = ret.fid;
+    if (ftype == Thrift.Type.STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+      if (ftype == Thrift.Type.STRING) {
+        this.Name = input.readString();
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 2:
+      if (ftype == Thrift.Type.I64) {
+        this.Value = input.readI64();
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      default:
+        input.skip(ftype);
+    }
+    input.readFieldEnd();
+  }
+  input.readStructEnd();
+  return;
+};
+
+crouton_thrift.NamedCounter.prototype.write = function(output) {
+  output.writeStructBegin('NamedCounter');
+  if (this.Name !== null && this.Name !== undefined) {
+    output.writeFieldBegin('Name', Thrift.Type.STRING, 1);
+    output.writeString(this.Name);
+    output.writeFieldEnd();
+  }
+  if (this.Value !== null && this.Value !== undefined) {
+    output.writeFieldBegin('Value', Thrift.Type.I64, 2);
+    output.writeI64(this.Value);
+    output.writeFieldEnd();
+  }
+  output.writeFieldStop();
+  output.writeStructEnd();
+  return;
+};
+
 crouton_thrift.Runtime = module.exports.Runtime = function(args) {
   this.guid = null;
   this.start_micros = null;
@@ -905,6 +975,88 @@ crouton_thrift.Timing.prototype.write = function(output) {
   return;
 };
 
+crouton_thrift.SampleCount = module.exports.SampleCount = function(args) {
+  this.oldest_micros = null;
+  this.youngest_micros = null;
+  this.count = null;
+  if (args) {
+    if (args.oldest_micros !== undefined) {
+      this.oldest_micros = args.oldest_micros;
+    }
+    if (args.youngest_micros !== undefined) {
+      this.youngest_micros = args.youngest_micros;
+    }
+    if (args.count !== undefined) {
+      this.count = args.count;
+    }
+  }
+};
+crouton_thrift.SampleCount.prototype = {};
+crouton_thrift.SampleCount.prototype.read = function(input) {
+  input.readStructBegin();
+  while (true)
+  {
+    var ret = input.readFieldBegin();
+    var fname = ret.fname;
+    var ftype = ret.ftype;
+    var fid = ret.fid;
+    if (ftype == Thrift.Type.STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+      if (ftype == Thrift.Type.I64) {
+        this.oldest_micros = input.readI64();
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 2:
+      if (ftype == Thrift.Type.I64) {
+        this.youngest_micros = input.readI64();
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 3:
+      if (ftype == Thrift.Type.I64) {
+        this.count = input.readI64();
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      default:
+        input.skip(ftype);
+    }
+    input.readFieldEnd();
+  }
+  input.readStructEnd();
+  return;
+};
+
+crouton_thrift.SampleCount.prototype.write = function(output) {
+  output.writeStructBegin('SampleCount');
+  if (this.oldest_micros !== null && this.oldest_micros !== undefined) {
+    output.writeFieldBegin('oldest_micros', Thrift.Type.I64, 1);
+    output.writeI64(this.oldest_micros);
+    output.writeFieldEnd();
+  }
+  if (this.youngest_micros !== null && this.youngest_micros !== undefined) {
+    output.writeFieldBegin('youngest_micros', Thrift.Type.I64, 2);
+    output.writeI64(this.youngest_micros);
+    output.writeFieldEnd();
+  }
+  if (this.count !== null && this.count !== undefined) {
+    output.writeFieldBegin('count', Thrift.Type.I64, 3);
+    output.writeI64(this.count);
+    output.writeFieldEnd();
+  }
+  output.writeFieldStop();
+  output.writeStructEnd();
+  return;
+};
+
 crouton_thrift.MetricsSample = module.exports.MetricsSample = function(args) {
   this.name = null;
   this.int64_value = null;
@@ -1072,6 +1224,7 @@ crouton_thrift.ReportRequest = module.exports.ReportRequest = function(args) {
   this.timestamp_offset_micros = null;
   this.oldest_micros = null;
   this.youngest_micros = null;
+  this.counters = null;
   this.internal_logs = null;
   this.internal_metrics = null;
   if (args) {
@@ -1092,6 +1245,9 @@ crouton_thrift.ReportRequest = module.exports.ReportRequest = function(args) {
     }
     if (args.youngest_micros !== undefined) {
       this.youngest_micros = args.youngest_micros;
+    }
+    if (args.counters !== undefined) {
+      this.counters = args.counters;
     }
     if (args.internal_logs !== undefined) {
       this.internal_logs = args.internal_logs;
@@ -1186,11 +1342,11 @@ crouton_thrift.ReportRequest.prototype.read = function(input) {
         input.skip(ftype);
       }
       break;
-      case 10:
+      case 9:
       if (ftype == Thrift.Type.LIST) {
         var _size62 = 0;
         var _rtmp366;
-        this.internal_logs = [];
+        this.counters = [];
         var _etype65 = 0;
         _rtmp366 = input.readListBegin();
         _etype65 = _rtmp366.etype;
@@ -1198,9 +1354,30 @@ crouton_thrift.ReportRequest.prototype.read = function(input) {
         for (var _i67 = 0; _i67 < _size62; ++_i67)
         {
           var elem68 = null;
-          elem68 = new ttypes.LogRecord();
+          elem68 = new ttypes.NamedCounter();
           elem68.read(input);
-          this.internal_logs.push(elem68);
+          this.counters.push(elem68);
+        }
+        input.readListEnd();
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 10:
+      if (ftype == Thrift.Type.LIST) {
+        var _size69 = 0;
+        var _rtmp373;
+        this.internal_logs = [];
+        var _etype72 = 0;
+        _rtmp373 = input.readListBegin();
+        _etype72 = _rtmp373.etype;
+        _size69 = _rtmp373.size;
+        for (var _i74 = 0; _i74 < _size69; ++_i74)
+        {
+          var elem75 = null;
+          elem75 = new ttypes.LogRecord();
+          elem75.read(input);
+          this.internal_logs.push(elem75);
         }
         input.readListEnd();
       } else {
@@ -1234,12 +1411,12 @@ crouton_thrift.ReportRequest.prototype.write = function(output) {
   if (this.span_records !== null && this.span_records !== undefined) {
     output.writeFieldBegin('span_records', Thrift.Type.LIST, 3);
     output.writeListBegin(Thrift.Type.STRUCT, this.span_records.length);
-    for (var iter69 in this.span_records)
+    for (var iter76 in this.span_records)
     {
-      if (this.span_records.hasOwnProperty(iter69))
+      if (this.span_records.hasOwnProperty(iter76))
       {
-        iter69 = this.span_records[iter69];
-        iter69.write(output);
+        iter76 = this.span_records[iter76];
+        iter76.write(output);
       }
     }
     output.writeListEnd();
@@ -1248,12 +1425,12 @@ crouton_thrift.ReportRequest.prototype.write = function(output) {
   if (this.log_records !== null && this.log_records !== undefined) {
     output.writeFieldBegin('log_records', Thrift.Type.LIST, 4);
     output.writeListBegin(Thrift.Type.STRUCT, this.log_records.length);
-    for (var iter70 in this.log_records)
+    for (var iter77 in this.log_records)
     {
-      if (this.log_records.hasOwnProperty(iter70))
+      if (this.log_records.hasOwnProperty(iter77))
       {
-        iter70 = this.log_records[iter70];
-        iter70.write(output);
+        iter77 = this.log_records[iter77];
+        iter77.write(output);
       }
     }
     output.writeListEnd();
@@ -1274,15 +1451,29 @@ crouton_thrift.ReportRequest.prototype.write = function(output) {
     output.writeI64(this.youngest_micros);
     output.writeFieldEnd();
   }
+  if (this.counters !== null && this.counters !== undefined) {
+    output.writeFieldBegin('counters', Thrift.Type.LIST, 9);
+    output.writeListBegin(Thrift.Type.STRUCT, this.counters.length);
+    for (var iter78 in this.counters)
+    {
+      if (this.counters.hasOwnProperty(iter78))
+      {
+        iter78 = this.counters[iter78];
+        iter78.write(output);
+      }
+    }
+    output.writeListEnd();
+    output.writeFieldEnd();
+  }
   if (this.internal_logs !== null && this.internal_logs !== undefined) {
     output.writeFieldBegin('internal_logs', Thrift.Type.LIST, 10);
     output.writeListBegin(Thrift.Type.STRUCT, this.internal_logs.length);
-    for (var iter71 in this.internal_logs)
+    for (var iter79 in this.internal_logs)
     {
-      if (this.internal_logs.hasOwnProperty(iter71))
+      if (this.internal_logs.hasOwnProperty(iter79))
       {
-        iter71 = this.internal_logs[iter71];
-        iter71.write(output);
+        iter79 = this.internal_logs[iter79];
+        iter79.write(output);
       }
     }
     output.writeListEnd();
@@ -1383,19 +1574,19 @@ crouton_thrift.ReportResponse.prototype.read = function(input) {
     {
       case 1:
       if (ftype == Thrift.Type.LIST) {
-        var _size72 = 0;
-        var _rtmp376;
+        var _size80 = 0;
+        var _rtmp384;
         this.commands = [];
-        var _etype75 = 0;
-        _rtmp376 = input.readListBegin();
-        _etype75 = _rtmp376.etype;
-        _size72 = _rtmp376.size;
-        for (var _i77 = 0; _i77 < _size72; ++_i77)
+        var _etype83 = 0;
+        _rtmp384 = input.readListBegin();
+        _etype83 = _rtmp384.etype;
+        _size80 = _rtmp384.size;
+        for (var _i85 = 0; _i85 < _size80; ++_i85)
         {
-          var elem78 = null;
-          elem78 = new ttypes.Command();
-          elem78.read(input);
-          this.commands.push(elem78);
+          var elem86 = null;
+          elem86 = new ttypes.Command();
+          elem86.read(input);
+          this.commands.push(elem86);
         }
         input.readListEnd();
       } else {
@@ -1412,18 +1603,18 @@ crouton_thrift.ReportResponse.prototype.read = function(input) {
       break;
       case 3:
       if (ftype == Thrift.Type.LIST) {
-        var _size79 = 0;
-        var _rtmp383;
+        var _size87 = 0;
+        var _rtmp391;
         this.errors = [];
-        var _etype82 = 0;
-        _rtmp383 = input.readListBegin();
-        _etype82 = _rtmp383.etype;
-        _size79 = _rtmp383.size;
-        for (var _i84 = 0; _i84 < _size79; ++_i84)
+        var _etype90 = 0;
+        _rtmp391 = input.readListBegin();
+        _etype90 = _rtmp391.etype;
+        _size87 = _rtmp391.size;
+        for (var _i92 = 0; _i92 < _size87; ++_i92)
         {
-          var elem85 = null;
-          elem85 = input.readString();
-          this.errors.push(elem85);
+          var elem93 = null;
+          elem93 = input.readString();
+          this.errors.push(elem93);
         }
         input.readListEnd();
       } else {
@@ -1444,12 +1635,12 @@ crouton_thrift.ReportResponse.prototype.write = function(output) {
   if (this.commands !== null && this.commands !== undefined) {
     output.writeFieldBegin('commands', Thrift.Type.LIST, 1);
     output.writeListBegin(Thrift.Type.STRUCT, this.commands.length);
-    for (var iter86 in this.commands)
+    for (var iter94 in this.commands)
     {
-      if (this.commands.hasOwnProperty(iter86))
+      if (this.commands.hasOwnProperty(iter94))
       {
-        iter86 = this.commands[iter86];
-        iter86.write(output);
+        iter94 = this.commands[iter94];
+        iter94.write(output);
       }
     }
     output.writeListEnd();
@@ -1463,12 +1654,12 @@ crouton_thrift.ReportResponse.prototype.write = function(output) {
   if (this.errors !== null && this.errors !== undefined) {
     output.writeFieldBegin('errors', Thrift.Type.LIST, 3);
     output.writeListBegin(Thrift.Type.STRING, this.errors.length);
-    for (var iter87 in this.errors)
+    for (var iter95 in this.errors)
     {
-      if (this.errors.hasOwnProperty(iter87))
+      if (this.errors.hasOwnProperty(iter95))
       {
-        iter87 = this.errors[iter87];
-        output.writeString(iter87);
+        iter95 = this.errors[iter95];
+        output.writeString(iter95);
       }
     }
     output.writeListEnd();

--- a/src/imp/platform/node/platform_node.js
+++ b/src/imp/platform/node/platform_node.js
@@ -103,27 +103,28 @@ export default class PlatformNode {
         if (!(process && process.argv)) {
             return;
         }
-
         let opts = {};
         for (let key in process.argv) {
             const value = process.argv[key];
+
+            // Keep the argument "parsing" simple.  These are primarily debug
+            // options regardless.
             switch (value.toLowerCase()) {
             case '--lightstep-log_to_console':
             case '--lightstep-log_to_console=true':
             case '--lightstep-log_to_console=1':
                 opts.log_to_console = true;
                 break;
-
-            case '--lightstep-debug':
-            case '--lightstep-debug=true':
-            case '--lightstep-debug=1':
-                opts.debug = true;
+            case '--lightstep-verbosity=4':
+                opts.verbosity = 4;
                 break;
-
-            case '--lightstep-verbose=2':
+            case '--lightstep-verbosity=3':
+                opts.verbosity = 3;
+                break;
+            case '--lightstep-verbosity=2':
                 opts.verbosity = 2;
                 break;
-            case '--lightstep-verbose=1':
+            case '--lightstep-verbosity=1':
                 opts.verbosity = 1;
                 break;
             default:

--- a/src/imp/platform/node/thrift_api/crouton_types.js
+++ b/src/imp/platform/node/thrift_api/crouton_types.js
@@ -82,76 +82,6 @@ crouton_thrift.KeyValue.prototype.write = function(output) {
   return;
 };
 
-crouton_thrift.NamedCounter = module.exports.NamedCounter = function(args) {
-  this.Name = null;
-  this.Value = null;
-  if (args) {
-    if (args.Name !== undefined) {
-      this.Name = args.Name;
-    } else {
-      throw new Thrift.TProtocolException(Thrift.TProtocolExceptionType.UNKNOWN, 'Required field Name is unset!');
-    }
-    if (args.Value !== undefined) {
-      this.Value = args.Value;
-    } else {
-      throw new Thrift.TProtocolException(Thrift.TProtocolExceptionType.UNKNOWN, 'Required field Value is unset!');
-    }
-  }
-};
-crouton_thrift.NamedCounter.prototype = {};
-crouton_thrift.NamedCounter.prototype.read = function(input) {
-  input.readStructBegin();
-  while (true)
-  {
-    var ret = input.readFieldBegin();
-    var fname = ret.fname;
-    var ftype = ret.ftype;
-    var fid = ret.fid;
-    if (ftype == Thrift.Type.STOP) {
-      break;
-    }
-    switch (fid)
-    {
-      case 1:
-      if (ftype == Thrift.Type.STRING) {
-        this.Name = input.readString();
-      } else {
-        input.skip(ftype);
-      }
-      break;
-      case 2:
-      if (ftype == Thrift.Type.I64) {
-        this.Value = input.readI64();
-      } else {
-        input.skip(ftype);
-      }
-      break;
-      default:
-        input.skip(ftype);
-    }
-    input.readFieldEnd();
-  }
-  input.readStructEnd();
-  return;
-};
-
-crouton_thrift.NamedCounter.prototype.write = function(output) {
-  output.writeStructBegin('NamedCounter');
-  if (this.Name !== null && this.Name !== undefined) {
-    output.writeFieldBegin('Name', Thrift.Type.STRING, 1);
-    output.writeString(this.Name);
-    output.writeFieldEnd();
-  }
-  if (this.Value !== null && this.Value !== undefined) {
-    output.writeFieldBegin('Value', Thrift.Type.I64, 2);
-    output.writeI64(this.Value);
-    output.writeFieldEnd();
-  }
-  output.writeFieldStop();
-  output.writeStructEnd();
-  return;
-};
-
 crouton_thrift.Runtime = module.exports.Runtime = function(args) {
   this.guid = null;
   this.start_micros = null;
@@ -973,24 +903,26 @@ crouton_thrift.Timing.prototype.write = function(output) {
   return;
 };
 
-crouton_thrift.SampleCount = module.exports.SampleCount = function(args) {
-  this.oldest_micros = null;
-  this.youngest_micros = null;
-  this.count = null;
+crouton_thrift.MetricsSample = module.exports.MetricsSample = function(args) {
+  this.name = null;
+  this.int64_value = null;
+  this.double_value = null;
   if (args) {
-    if (args.oldest_micros !== undefined) {
-      this.oldest_micros = args.oldest_micros;
+    if (args.name !== undefined) {
+      this.name = args.name;
+    } else {
+      throw new Thrift.TProtocolException(Thrift.TProtocolExceptionType.UNKNOWN, 'Required field name is unset!');
     }
-    if (args.youngest_micros !== undefined) {
-      this.youngest_micros = args.youngest_micros;
+    if (args.int64_value !== undefined) {
+      this.int64_value = args.int64_value;
     }
-    if (args.count !== undefined) {
-      this.count = args.count;
+    if (args.double_value !== undefined) {
+      this.double_value = args.double_value;
     }
   }
 };
-crouton_thrift.SampleCount.prototype = {};
-crouton_thrift.SampleCount.prototype.read = function(input) {
+crouton_thrift.MetricsSample.prototype = {};
+crouton_thrift.MetricsSample.prototype.read = function(input) {
   input.readStructBegin();
   while (true)
   {
@@ -1004,22 +936,22 @@ crouton_thrift.SampleCount.prototype.read = function(input) {
     switch (fid)
     {
       case 1:
-      if (ftype == Thrift.Type.I64) {
-        this.oldest_micros = input.readI64();
+      if (ftype == Thrift.Type.STRING) {
+        this.name = input.readString();
       } else {
         input.skip(ftype);
       }
       break;
       case 2:
       if (ftype == Thrift.Type.I64) {
-        this.youngest_micros = input.readI64();
+        this.int64_value = input.readI64();
       } else {
         input.skip(ftype);
       }
       break;
       case 3:
-      if (ftype == Thrift.Type.I64) {
-        this.count = input.readI64();
+      if (ftype == Thrift.Type.DOUBLE) {
+        this.double_value = input.readDouble();
       } else {
         input.skip(ftype);
       }
@@ -1033,21 +965,97 @@ crouton_thrift.SampleCount.prototype.read = function(input) {
   return;
 };
 
-crouton_thrift.SampleCount.prototype.write = function(output) {
-  output.writeStructBegin('SampleCount');
-  if (this.oldest_micros !== null && this.oldest_micros !== undefined) {
-    output.writeFieldBegin('oldest_micros', Thrift.Type.I64, 1);
-    output.writeI64(this.oldest_micros);
+crouton_thrift.MetricsSample.prototype.write = function(output) {
+  output.writeStructBegin('MetricsSample');
+  if (this.name !== null && this.name !== undefined) {
+    output.writeFieldBegin('name', Thrift.Type.STRING, 1);
+    output.writeString(this.name);
     output.writeFieldEnd();
   }
-  if (this.youngest_micros !== null && this.youngest_micros !== undefined) {
-    output.writeFieldBegin('youngest_micros', Thrift.Type.I64, 2);
-    output.writeI64(this.youngest_micros);
+  if (this.int64_value !== null && this.int64_value !== undefined) {
+    output.writeFieldBegin('int64_value', Thrift.Type.I64, 2);
+    output.writeI64(this.int64_value);
     output.writeFieldEnd();
   }
-  if (this.count !== null && this.count !== undefined) {
-    output.writeFieldBegin('count', Thrift.Type.I64, 3);
-    output.writeI64(this.count);
+  if (this.double_value !== null && this.double_value !== undefined) {
+    output.writeFieldBegin('double_value', Thrift.Type.DOUBLE, 3);
+    output.writeDouble(this.double_value);
+    output.writeFieldEnd();
+  }
+  output.writeFieldStop();
+  output.writeStructEnd();
+  return;
+};
+
+crouton_thrift.Metrics = module.exports.Metrics = function(args) {
+  this.counts = null;
+  if (args) {
+    if (args.counts !== undefined) {
+      this.counts = args.counts;
+    }
+  }
+};
+crouton_thrift.Metrics.prototype = {};
+crouton_thrift.Metrics.prototype.read = function(input) {
+  input.readStructBegin();
+  while (true)
+  {
+    var ret = input.readFieldBegin();
+    var fname = ret.fname;
+    var ftype = ret.ftype;
+    var fid = ret.fid;
+    if (ftype == Thrift.Type.STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+      if (ftype == Thrift.Type.LIST) {
+        var _size40 = 0;
+        var _rtmp344;
+        this.counts = [];
+        var _etype43 = 0;
+        _rtmp344 = input.readListBegin();
+        _etype43 = _rtmp344.etype;
+        _size40 = _rtmp344.size;
+        for (var _i45 = 0; _i45 < _size40; ++_i45)
+        {
+          var elem46 = null;
+          elem46 = new ttypes.MetricsSample();
+          elem46.read(input);
+          this.counts.push(elem46);
+        }
+        input.readListEnd();
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 0:
+        input.skip(ftype);
+        break;
+      default:
+        input.skip(ftype);
+    }
+    input.readFieldEnd();
+  }
+  input.readStructEnd();
+  return;
+};
+
+crouton_thrift.Metrics.prototype.write = function(output) {
+  output.writeStructBegin('Metrics');
+  if (this.counts !== null && this.counts !== undefined) {
+    output.writeFieldBegin('counts', Thrift.Type.LIST, 1);
+    output.writeListBegin(Thrift.Type.STRUCT, this.counts.length);
+    for (var iter47 in this.counts)
+    {
+      if (this.counts.hasOwnProperty(iter47))
+      {
+        iter47 = this.counts[iter47];
+        iter47.write(output);
+      }
+    }
+    output.writeListEnd();
     output.writeFieldEnd();
   }
   output.writeFieldStop();
@@ -1062,7 +1070,8 @@ crouton_thrift.ReportRequest = module.exports.ReportRequest = function(args) {
   this.timestamp_offset_micros = null;
   this.oldest_micros = null;
   this.youngest_micros = null;
-  this.counters = null;
+  this.internal_logs = null;
+  this.internal_metrics = null;
   if (args) {
     if (args.runtime !== undefined) {
       this.runtime = args.runtime;
@@ -1082,8 +1091,11 @@ crouton_thrift.ReportRequest = module.exports.ReportRequest = function(args) {
     if (args.youngest_micros !== undefined) {
       this.youngest_micros = args.youngest_micros;
     }
-    if (args.counters !== undefined) {
-      this.counters = args.counters;
+    if (args.internal_logs !== undefined) {
+      this.internal_logs = args.internal_logs;
+    }
+    if (args.internal_metrics !== undefined) {
+      this.internal_metrics = args.internal_metrics;
     }
   }
 };
@@ -1111,19 +1123,19 @@ crouton_thrift.ReportRequest.prototype.read = function(input) {
       break;
       case 3:
       if (ftype == Thrift.Type.LIST) {
-        var _size40 = 0;
-        var _rtmp344;
+        var _size48 = 0;
+        var _rtmp352;
         this.span_records = [];
-        var _etype43 = 0;
-        _rtmp344 = input.readListBegin();
-        _etype43 = _rtmp344.etype;
-        _size40 = _rtmp344.size;
-        for (var _i45 = 0; _i45 < _size40; ++_i45)
+        var _etype51 = 0;
+        _rtmp352 = input.readListBegin();
+        _etype51 = _rtmp352.etype;
+        _size48 = _rtmp352.size;
+        for (var _i53 = 0; _i53 < _size48; ++_i53)
         {
-          var elem46 = null;
-          elem46 = new ttypes.SpanRecord();
-          elem46.read(input);
-          this.span_records.push(elem46);
+          var elem54 = null;
+          elem54 = new ttypes.SpanRecord();
+          elem54.read(input);
+          this.span_records.push(elem54);
         }
         input.readListEnd();
       } else {
@@ -1132,19 +1144,19 @@ crouton_thrift.ReportRequest.prototype.read = function(input) {
       break;
       case 4:
       if (ftype == Thrift.Type.LIST) {
-        var _size47 = 0;
-        var _rtmp351;
+        var _size55 = 0;
+        var _rtmp359;
         this.log_records = [];
-        var _etype50 = 0;
-        _rtmp351 = input.readListBegin();
-        _etype50 = _rtmp351.etype;
-        _size47 = _rtmp351.size;
-        for (var _i52 = 0; _i52 < _size47; ++_i52)
+        var _etype58 = 0;
+        _rtmp359 = input.readListBegin();
+        _etype58 = _rtmp359.etype;
+        _size55 = _rtmp359.size;
+        for (var _i60 = 0; _i60 < _size55; ++_i60)
         {
-          var elem53 = null;
-          elem53 = new ttypes.LogRecord();
-          elem53.read(input);
-          this.log_records.push(elem53);
+          var elem61 = null;
+          elem61 = new ttypes.LogRecord();
+          elem61.read(input);
+          this.log_records.push(elem61);
         }
         input.readListEnd();
       } else {
@@ -1172,23 +1184,31 @@ crouton_thrift.ReportRequest.prototype.read = function(input) {
         input.skip(ftype);
       }
       break;
-      case 9:
+      case 10:
       if (ftype == Thrift.Type.LIST) {
-        var _size54 = 0;
-        var _rtmp358;
-        this.counters = [];
-        var _etype57 = 0;
-        _rtmp358 = input.readListBegin();
-        _etype57 = _rtmp358.etype;
-        _size54 = _rtmp358.size;
-        for (var _i59 = 0; _i59 < _size54; ++_i59)
+        var _size62 = 0;
+        var _rtmp366;
+        this.internal_logs = [];
+        var _etype65 = 0;
+        _rtmp366 = input.readListBegin();
+        _etype65 = _rtmp366.etype;
+        _size62 = _rtmp366.size;
+        for (var _i67 = 0; _i67 < _size62; ++_i67)
         {
-          var elem60 = null;
-          elem60 = new ttypes.NamedCounter();
-          elem60.read(input);
-          this.counters.push(elem60);
+          var elem68 = null;
+          elem68 = new ttypes.LogRecord();
+          elem68.read(input);
+          this.internal_logs.push(elem68);
         }
         input.readListEnd();
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 11:
+      if (ftype == Thrift.Type.STRUCT) {
+        this.internal_metrics = new ttypes.Metrics();
+        this.internal_metrics.read(input);
       } else {
         input.skip(ftype);
       }
@@ -1212,12 +1232,12 @@ crouton_thrift.ReportRequest.prototype.write = function(output) {
   if (this.span_records !== null && this.span_records !== undefined) {
     output.writeFieldBegin('span_records', Thrift.Type.LIST, 3);
     output.writeListBegin(Thrift.Type.STRUCT, this.span_records.length);
-    for (var iter61 in this.span_records)
+    for (var iter69 in this.span_records)
     {
-      if (this.span_records.hasOwnProperty(iter61))
+      if (this.span_records.hasOwnProperty(iter69))
       {
-        iter61 = this.span_records[iter61];
-        iter61.write(output);
+        iter69 = this.span_records[iter69];
+        iter69.write(output);
       }
     }
     output.writeListEnd();
@@ -1226,12 +1246,12 @@ crouton_thrift.ReportRequest.prototype.write = function(output) {
   if (this.log_records !== null && this.log_records !== undefined) {
     output.writeFieldBegin('log_records', Thrift.Type.LIST, 4);
     output.writeListBegin(Thrift.Type.STRUCT, this.log_records.length);
-    for (var iter62 in this.log_records)
+    for (var iter70 in this.log_records)
     {
-      if (this.log_records.hasOwnProperty(iter62))
+      if (this.log_records.hasOwnProperty(iter70))
       {
-        iter62 = this.log_records[iter62];
-        iter62.write(output);
+        iter70 = this.log_records[iter70];
+        iter70.write(output);
       }
     }
     output.writeListEnd();
@@ -1252,18 +1272,23 @@ crouton_thrift.ReportRequest.prototype.write = function(output) {
     output.writeI64(this.youngest_micros);
     output.writeFieldEnd();
   }
-  if (this.counters !== null && this.counters !== undefined) {
-    output.writeFieldBegin('counters', Thrift.Type.LIST, 9);
-    output.writeListBegin(Thrift.Type.STRUCT, this.counters.length);
-    for (var iter63 in this.counters)
+  if (this.internal_logs !== null && this.internal_logs !== undefined) {
+    output.writeFieldBegin('internal_logs', Thrift.Type.LIST, 10);
+    output.writeListBegin(Thrift.Type.STRUCT, this.internal_logs.length);
+    for (var iter71 in this.internal_logs)
     {
-      if (this.counters.hasOwnProperty(iter63))
+      if (this.internal_logs.hasOwnProperty(iter71))
       {
-        iter63 = this.counters[iter63];
-        iter63.write(output);
+        iter71 = this.internal_logs[iter71];
+        iter71.write(output);
       }
     }
     output.writeListEnd();
+    output.writeFieldEnd();
+  }
+  if (this.internal_metrics !== null && this.internal_metrics !== undefined) {
+    output.writeFieldBegin('internal_metrics', Thrift.Type.STRUCT, 11);
+    this.internal_metrics.write(output);
     output.writeFieldEnd();
   }
   output.writeFieldStop();
@@ -1356,19 +1381,19 @@ crouton_thrift.ReportResponse.prototype.read = function(input) {
     {
       case 1:
       if (ftype == Thrift.Type.LIST) {
-        var _size64 = 0;
-        var _rtmp368;
+        var _size72 = 0;
+        var _rtmp376;
         this.commands = [];
-        var _etype67 = 0;
-        _rtmp368 = input.readListBegin();
-        _etype67 = _rtmp368.etype;
-        _size64 = _rtmp368.size;
-        for (var _i69 = 0; _i69 < _size64; ++_i69)
+        var _etype75 = 0;
+        _rtmp376 = input.readListBegin();
+        _etype75 = _rtmp376.etype;
+        _size72 = _rtmp376.size;
+        for (var _i77 = 0; _i77 < _size72; ++_i77)
         {
-          var elem70 = null;
-          elem70 = new ttypes.Command();
-          elem70.read(input);
-          this.commands.push(elem70);
+          var elem78 = null;
+          elem78 = new ttypes.Command();
+          elem78.read(input);
+          this.commands.push(elem78);
         }
         input.readListEnd();
       } else {
@@ -1385,18 +1410,18 @@ crouton_thrift.ReportResponse.prototype.read = function(input) {
       break;
       case 3:
       if (ftype == Thrift.Type.LIST) {
-        var _size71 = 0;
-        var _rtmp375;
+        var _size79 = 0;
+        var _rtmp383;
         this.errors = [];
-        var _etype74 = 0;
-        _rtmp375 = input.readListBegin();
-        _etype74 = _rtmp375.etype;
-        _size71 = _rtmp375.size;
-        for (var _i76 = 0; _i76 < _size71; ++_i76)
+        var _etype82 = 0;
+        _rtmp383 = input.readListBegin();
+        _etype82 = _rtmp383.etype;
+        _size79 = _rtmp383.size;
+        for (var _i84 = 0; _i84 < _size79; ++_i84)
         {
-          var elem77 = null;
-          elem77 = input.readString();
-          this.errors.push(elem77);
+          var elem85 = null;
+          elem85 = input.readString();
+          this.errors.push(elem85);
         }
         input.readListEnd();
       } else {
@@ -1417,12 +1442,12 @@ crouton_thrift.ReportResponse.prototype.write = function(output) {
   if (this.commands !== null && this.commands !== undefined) {
     output.writeFieldBegin('commands', Thrift.Type.LIST, 1);
     output.writeListBegin(Thrift.Type.STRUCT, this.commands.length);
-    for (var iter78 in this.commands)
+    for (var iter86 in this.commands)
     {
-      if (this.commands.hasOwnProperty(iter78))
+      if (this.commands.hasOwnProperty(iter86))
       {
-        iter78 = this.commands[iter78];
-        iter78.write(output);
+        iter86 = this.commands[iter86];
+        iter86.write(output);
       }
     }
     output.writeListEnd();
@@ -1436,12 +1461,12 @@ crouton_thrift.ReportResponse.prototype.write = function(output) {
   if (this.errors !== null && this.errors !== undefined) {
     output.writeFieldBegin('errors', Thrift.Type.LIST, 3);
     output.writeListBegin(Thrift.Type.STRING, this.errors.length);
-    for (var iter79 in this.errors)
+    for (var iter87 in this.errors)
     {
-      if (this.errors.hasOwnProperty(iter79))
+      if (this.errors.hasOwnProperty(iter87))
       {
-        iter79 = this.errors[iter79];
-        output.writeString(iter79);
+        iter87 = this.errors[iter87];
+        output.writeString(iter87);
       }
     }
     output.writeListEnd();

--- a/src/imp/platform/node/thrift_api/crouton_types.js
+++ b/src/imp/platform/node/thrift_api/crouton_types.js
@@ -82,6 +82,76 @@ crouton_thrift.KeyValue.prototype.write = function(output) {
   return;
 };
 
+crouton_thrift.NamedCounter = module.exports.NamedCounter = function(args) {
+  this.Name = null;
+  this.Value = null;
+  if (args) {
+    if (args.Name !== undefined) {
+      this.Name = args.Name;
+    } else {
+      throw new Thrift.TProtocolException(Thrift.TProtocolExceptionType.UNKNOWN, 'Required field Name is unset!');
+    }
+    if (args.Value !== undefined) {
+      this.Value = args.Value;
+    } else {
+      throw new Thrift.TProtocolException(Thrift.TProtocolExceptionType.UNKNOWN, 'Required field Value is unset!');
+    }
+  }
+};
+crouton_thrift.NamedCounter.prototype = {};
+crouton_thrift.NamedCounter.prototype.read = function(input) {
+  input.readStructBegin();
+  while (true)
+  {
+    var ret = input.readFieldBegin();
+    var fname = ret.fname;
+    var ftype = ret.ftype;
+    var fid = ret.fid;
+    if (ftype == Thrift.Type.STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+      if (ftype == Thrift.Type.STRING) {
+        this.Name = input.readString();
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 2:
+      if (ftype == Thrift.Type.I64) {
+        this.Value = input.readI64();
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      default:
+        input.skip(ftype);
+    }
+    input.readFieldEnd();
+  }
+  input.readStructEnd();
+  return;
+};
+
+crouton_thrift.NamedCounter.prototype.write = function(output) {
+  output.writeStructBegin('NamedCounter');
+  if (this.Name !== null && this.Name !== undefined) {
+    output.writeFieldBegin('Name', Thrift.Type.STRING, 1);
+    output.writeString(this.Name);
+    output.writeFieldEnd();
+  }
+  if (this.Value !== null && this.Value !== undefined) {
+    output.writeFieldBegin('Value', Thrift.Type.I64, 2);
+    output.writeI64(this.Value);
+    output.writeFieldEnd();
+  }
+  output.writeFieldStop();
+  output.writeStructEnd();
+  return;
+};
+
 crouton_thrift.Runtime = module.exports.Runtime = function(args) {
   this.guid = null;
   this.start_micros = null;
@@ -903,6 +973,88 @@ crouton_thrift.Timing.prototype.write = function(output) {
   return;
 };
 
+crouton_thrift.SampleCount = module.exports.SampleCount = function(args) {
+  this.oldest_micros = null;
+  this.youngest_micros = null;
+  this.count = null;
+  if (args) {
+    if (args.oldest_micros !== undefined) {
+      this.oldest_micros = args.oldest_micros;
+    }
+    if (args.youngest_micros !== undefined) {
+      this.youngest_micros = args.youngest_micros;
+    }
+    if (args.count !== undefined) {
+      this.count = args.count;
+    }
+  }
+};
+crouton_thrift.SampleCount.prototype = {};
+crouton_thrift.SampleCount.prototype.read = function(input) {
+  input.readStructBegin();
+  while (true)
+  {
+    var ret = input.readFieldBegin();
+    var fname = ret.fname;
+    var ftype = ret.ftype;
+    var fid = ret.fid;
+    if (ftype == Thrift.Type.STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+      if (ftype == Thrift.Type.I64) {
+        this.oldest_micros = input.readI64();
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 2:
+      if (ftype == Thrift.Type.I64) {
+        this.youngest_micros = input.readI64();
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 3:
+      if (ftype == Thrift.Type.I64) {
+        this.count = input.readI64();
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      default:
+        input.skip(ftype);
+    }
+    input.readFieldEnd();
+  }
+  input.readStructEnd();
+  return;
+};
+
+crouton_thrift.SampleCount.prototype.write = function(output) {
+  output.writeStructBegin('SampleCount');
+  if (this.oldest_micros !== null && this.oldest_micros !== undefined) {
+    output.writeFieldBegin('oldest_micros', Thrift.Type.I64, 1);
+    output.writeI64(this.oldest_micros);
+    output.writeFieldEnd();
+  }
+  if (this.youngest_micros !== null && this.youngest_micros !== undefined) {
+    output.writeFieldBegin('youngest_micros', Thrift.Type.I64, 2);
+    output.writeI64(this.youngest_micros);
+    output.writeFieldEnd();
+  }
+  if (this.count !== null && this.count !== undefined) {
+    output.writeFieldBegin('count', Thrift.Type.I64, 3);
+    output.writeI64(this.count);
+    output.writeFieldEnd();
+  }
+  output.writeFieldStop();
+  output.writeStructEnd();
+  return;
+};
+
 crouton_thrift.MetricsSample = module.exports.MetricsSample = function(args) {
   this.name = null;
   this.int64_value = null;
@@ -1070,6 +1222,7 @@ crouton_thrift.ReportRequest = module.exports.ReportRequest = function(args) {
   this.timestamp_offset_micros = null;
   this.oldest_micros = null;
   this.youngest_micros = null;
+  this.counters = null;
   this.internal_logs = null;
   this.internal_metrics = null;
   if (args) {
@@ -1090,6 +1243,9 @@ crouton_thrift.ReportRequest = module.exports.ReportRequest = function(args) {
     }
     if (args.youngest_micros !== undefined) {
       this.youngest_micros = args.youngest_micros;
+    }
+    if (args.counters !== undefined) {
+      this.counters = args.counters;
     }
     if (args.internal_logs !== undefined) {
       this.internal_logs = args.internal_logs;
@@ -1184,11 +1340,11 @@ crouton_thrift.ReportRequest.prototype.read = function(input) {
         input.skip(ftype);
       }
       break;
-      case 10:
+      case 9:
       if (ftype == Thrift.Type.LIST) {
         var _size62 = 0;
         var _rtmp366;
-        this.internal_logs = [];
+        this.counters = [];
         var _etype65 = 0;
         _rtmp366 = input.readListBegin();
         _etype65 = _rtmp366.etype;
@@ -1196,9 +1352,30 @@ crouton_thrift.ReportRequest.prototype.read = function(input) {
         for (var _i67 = 0; _i67 < _size62; ++_i67)
         {
           var elem68 = null;
-          elem68 = new ttypes.LogRecord();
+          elem68 = new ttypes.NamedCounter();
           elem68.read(input);
-          this.internal_logs.push(elem68);
+          this.counters.push(elem68);
+        }
+        input.readListEnd();
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 10:
+      if (ftype == Thrift.Type.LIST) {
+        var _size69 = 0;
+        var _rtmp373;
+        this.internal_logs = [];
+        var _etype72 = 0;
+        _rtmp373 = input.readListBegin();
+        _etype72 = _rtmp373.etype;
+        _size69 = _rtmp373.size;
+        for (var _i74 = 0; _i74 < _size69; ++_i74)
+        {
+          var elem75 = null;
+          elem75 = new ttypes.LogRecord();
+          elem75.read(input);
+          this.internal_logs.push(elem75);
         }
         input.readListEnd();
       } else {
@@ -1232,12 +1409,12 @@ crouton_thrift.ReportRequest.prototype.write = function(output) {
   if (this.span_records !== null && this.span_records !== undefined) {
     output.writeFieldBegin('span_records', Thrift.Type.LIST, 3);
     output.writeListBegin(Thrift.Type.STRUCT, this.span_records.length);
-    for (var iter69 in this.span_records)
+    for (var iter76 in this.span_records)
     {
-      if (this.span_records.hasOwnProperty(iter69))
+      if (this.span_records.hasOwnProperty(iter76))
       {
-        iter69 = this.span_records[iter69];
-        iter69.write(output);
+        iter76 = this.span_records[iter76];
+        iter76.write(output);
       }
     }
     output.writeListEnd();
@@ -1246,12 +1423,12 @@ crouton_thrift.ReportRequest.prototype.write = function(output) {
   if (this.log_records !== null && this.log_records !== undefined) {
     output.writeFieldBegin('log_records', Thrift.Type.LIST, 4);
     output.writeListBegin(Thrift.Type.STRUCT, this.log_records.length);
-    for (var iter70 in this.log_records)
+    for (var iter77 in this.log_records)
     {
-      if (this.log_records.hasOwnProperty(iter70))
+      if (this.log_records.hasOwnProperty(iter77))
       {
-        iter70 = this.log_records[iter70];
-        iter70.write(output);
+        iter77 = this.log_records[iter77];
+        iter77.write(output);
       }
     }
     output.writeListEnd();
@@ -1272,15 +1449,29 @@ crouton_thrift.ReportRequest.prototype.write = function(output) {
     output.writeI64(this.youngest_micros);
     output.writeFieldEnd();
   }
+  if (this.counters !== null && this.counters !== undefined) {
+    output.writeFieldBegin('counters', Thrift.Type.LIST, 9);
+    output.writeListBegin(Thrift.Type.STRUCT, this.counters.length);
+    for (var iter78 in this.counters)
+    {
+      if (this.counters.hasOwnProperty(iter78))
+      {
+        iter78 = this.counters[iter78];
+        iter78.write(output);
+      }
+    }
+    output.writeListEnd();
+    output.writeFieldEnd();
+  }
   if (this.internal_logs !== null && this.internal_logs !== undefined) {
     output.writeFieldBegin('internal_logs', Thrift.Type.LIST, 10);
     output.writeListBegin(Thrift.Type.STRUCT, this.internal_logs.length);
-    for (var iter71 in this.internal_logs)
+    for (var iter79 in this.internal_logs)
     {
-      if (this.internal_logs.hasOwnProperty(iter71))
+      if (this.internal_logs.hasOwnProperty(iter79))
       {
-        iter71 = this.internal_logs[iter71];
-        iter71.write(output);
+        iter79 = this.internal_logs[iter79];
+        iter79.write(output);
       }
     }
     output.writeListEnd();
@@ -1381,19 +1572,19 @@ crouton_thrift.ReportResponse.prototype.read = function(input) {
     {
       case 1:
       if (ftype == Thrift.Type.LIST) {
-        var _size72 = 0;
-        var _rtmp376;
+        var _size80 = 0;
+        var _rtmp384;
         this.commands = [];
-        var _etype75 = 0;
-        _rtmp376 = input.readListBegin();
-        _etype75 = _rtmp376.etype;
-        _size72 = _rtmp376.size;
-        for (var _i77 = 0; _i77 < _size72; ++_i77)
+        var _etype83 = 0;
+        _rtmp384 = input.readListBegin();
+        _etype83 = _rtmp384.etype;
+        _size80 = _rtmp384.size;
+        for (var _i85 = 0; _i85 < _size80; ++_i85)
         {
-          var elem78 = null;
-          elem78 = new ttypes.Command();
-          elem78.read(input);
-          this.commands.push(elem78);
+          var elem86 = null;
+          elem86 = new ttypes.Command();
+          elem86.read(input);
+          this.commands.push(elem86);
         }
         input.readListEnd();
       } else {
@@ -1410,18 +1601,18 @@ crouton_thrift.ReportResponse.prototype.read = function(input) {
       break;
       case 3:
       if (ftype == Thrift.Type.LIST) {
-        var _size79 = 0;
-        var _rtmp383;
+        var _size87 = 0;
+        var _rtmp391;
         this.errors = [];
-        var _etype82 = 0;
-        _rtmp383 = input.readListBegin();
-        _etype82 = _rtmp383.etype;
-        _size79 = _rtmp383.size;
-        for (var _i84 = 0; _i84 < _size79; ++_i84)
+        var _etype90 = 0;
+        _rtmp391 = input.readListBegin();
+        _etype90 = _rtmp391.etype;
+        _size87 = _rtmp391.size;
+        for (var _i92 = 0; _i92 < _size87; ++_i92)
         {
-          var elem85 = null;
-          elem85 = input.readString();
-          this.errors.push(elem85);
+          var elem93 = null;
+          elem93 = input.readString();
+          this.errors.push(elem93);
         }
         input.readListEnd();
       } else {
@@ -1442,12 +1633,12 @@ crouton_thrift.ReportResponse.prototype.write = function(output) {
   if (this.commands !== null && this.commands !== undefined) {
     output.writeFieldBegin('commands', Thrift.Type.LIST, 1);
     output.writeListBegin(Thrift.Type.STRUCT, this.commands.length);
-    for (var iter86 in this.commands)
+    for (var iter94 in this.commands)
     {
-      if (this.commands.hasOwnProperty(iter86))
+      if (this.commands.hasOwnProperty(iter94))
       {
-        iter86 = this.commands[iter86];
-        iter86.write(output);
+        iter94 = this.commands[iter94];
+        iter94.write(output);
       }
     }
     output.writeListEnd();
@@ -1461,12 +1652,12 @@ crouton_thrift.ReportResponse.prototype.write = function(output) {
   if (this.errors !== null && this.errors !== undefined) {
     output.writeFieldBegin('errors', Thrift.Type.LIST, 3);
     output.writeListBegin(Thrift.Type.STRING, this.errors.length);
-    for (var iter87 in this.errors)
+    for (var iter95 in this.errors)
     {
-      if (this.errors.hasOwnProperty(iter87))
+      if (this.errors.hasOwnProperty(iter95))
       {
-        iter87 = this.errors[iter87];
-        output.writeString(iter87);
+        iter95 = this.errors[iter95];
+        output.writeString(iter95);
       }
     }
     output.writeListEnd();

--- a/src/imp/tracer_imp.js
+++ b/src/imp/tracer_imp.js
@@ -83,15 +83,12 @@ export default class TracerImp extends EventEmitter {
         // The counter names need to match those accepted by the collector.
         // These are internal counters only.
         this._counters = {
-            'logs.dropped'             : 0,
-            'logs.payloads.over_limit' : 0,
+            'internal.errors'          : 0,
+            'internal.warnings'        : 0,
             'spans.dropped'            : 0,
-
-            // TODO: these are not yet supported by the collector. Ensure these
-            // names are normalized across client libraries.
-            'reports.send_errors' : 0,
-            'internal.errors'     : 0,
-            'internal.warnings'   : 0,
+            'logs.dropped'             : 0,
+            'logs.payloads.over_limit' : 0,            
+            'reports.send_errors'      : 0,
         };
 
         // For internal (not client) logs reported to the collector

--- a/src/imp/tracer_imp.js
+++ b/src/imp/tracer_imp.js
@@ -1050,6 +1050,8 @@ export default class TracerImp extends EventEmitter {
                     if (res.errors && res.errors.length > 0) {
                         this._error('Errors in report', res.errors);
                     }
+                } else {
+                    this._useClockState = false;
                 }
 
                 this.emit('report', report, res);

--- a/src/imp/tracer_imp.js
+++ b/src/imp/tracer_imp.js
@@ -87,8 +87,8 @@ export default class TracerImp extends EventEmitter {
             'internal.warnings'        : 0,
             'spans.dropped'            : 0,
             'logs.dropped'             : 0,
-            'logs.payloads.over_limit' : 0,            
-            'reports.send_errors'      : 0,
+            'logs.payloads.over_limit' : 0,
+            'reports.errors.send'      : 0,
         };
 
         // For internal (not client) logs reported to the collector
@@ -1012,7 +1012,7 @@ export default class TracerImp extends EventEmitter {
                     report.counters);
 
                 // Increment the counter *after* the counters are restored
-                this._counters['reports.send_errors']++;
+                this._counters['reports.errors.send']++;
 
                 this.emit('report_error', err, {
                     error    : err,

--- a/src/imp/tracer_imp.js
+++ b/src/imp/tracer_imp.js
@@ -83,9 +83,9 @@ export default class TracerImp extends EventEmitter {
         // The counter names need to match those accepted by the collector.
         // These are internal counters only.
         this._counters = {
-            'logs.dropped'  : 0,
+            'logs.dropped'             : 0,
             'logs.payloads.over_limit' : 0,
-            'spans.dropped' : 0,
+            'spans.dropped'            : 0,
 
             // TODO: these are not yet supported by the collector. Ensure these
             // names are normalized across client libraries.
@@ -497,7 +497,6 @@ export default class TracerImp extends EventEmitter {
 
         // See if the Thrift data can be initialized
         if (this._options.access_token.length > 0 && this._options.component_name.length > 0) {
-
             this._runtimeGUID = this._platform.runtimeGUID(this._options.component_name);
 
             this._thriftAuth = new crouton_thrift.Auth({
@@ -1148,7 +1147,7 @@ export default class TracerImp extends EventEmitter {
 
     _pushInternalLog(record) {
         if (this._internalLogs.length >= MAX_INTERNAL_LOGS) {
-            record.message(`MAX_INTERNAL_LOGS limit hit. Last error: ${msg}`);
+            record.message(`MAX_INTERNAL_LOGS limit hit. Last error: ${record.message}`);
             this._internalLogs[this._internalLogs.length - 1] = record;
         } else {
             this._internalLogs.push(record);

--- a/test/manual/drop_spans/index.js
+++ b/test/manual/drop_spans/index.js
@@ -1,0 +1,28 @@
+'use strict';
+var Tracer    = require('opentracing');
+var LightStep = require('../../../dist/lightstep-tracer-node-debug');
+
+Tracer.initGlobalTracer(LightStep.tracer({
+    access_token   : '{your_access_token}',
+    component_name : 'lightstep-tracer/examples/node-trivial',
+    collector_host : 'localhost',
+    collector_port : 9998,
+    collector_encryption : 'none',
+    //disable_reporting_loop : true,
+}));
+
+var parent = Tracer.startSpan('parent');
+for (var i = 0; i < 20000; i++) {
+    var child = Tracer.startSpan('child', { parent: parent });
+    child.logEvent('log_event');
+    child.finish();
+}
+parent.finish();
+
+Tracer.imp().flush(function() {
+    var url = parent.imp().generateTraceURL();
+    console.log();
+    console.log(url);
+    console.log();
+    console.log(Tracer.imp().stats());
+});

--- a/test/suites/common/spans.js
+++ b/test/suites/common/spans.js
@@ -68,3 +68,12 @@ it("should handle inject / join to carriers correctly" , function() {
     expect(naps.getBaggageItem('footwear')).to.equal('sandals');
     expect(naps.getBaggageItem('creditcard')).to.equal('visa');
 });
+
+it('should gracefully handle a large number of spans', function() {
+    Tracer.imp().flush();
+    for (var i = 0; i < 10000; i++) {
+        var span = Tracer.startSpan('microspan');
+        span.finish();
+    }
+    Tracer.imp().flush();
+});

--- a/test/util/file_transport.js
+++ b/test/util/file_transport.js
@@ -45,6 +45,7 @@ FileTransport.prototype.report = function(detached, auth, report, done) {
     fs.writeFileSync(this._filename, JSON.stringify({
         requests : this._requests,
     }, null, 4));
+
     done();
 };
 


### PR DESCRIPTION
## Summary

* Bumps version to 0.10.0
* Changes `verbose` option to `verbosity`
* Removes `debug` option (superceded by `verbosity`)
* Changes internal logging and metrics (no external API impact)
* Updates internal Thrift generated files to latest protocol changes
* Adds `CHANGELOG.md` to document notable API and behavior changes