### PR TITLE
Use a thrift Docker image rather than requiring a local install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,8 +88,10 @@ update_examples: node_modules
 
 # LightStep internal target
 thrift:
-	thrift -r -gen js:node -out src/imp/platform/node/thrift_api $(LIGHTSTEP_HOME)/go/src/crouton/crouton.thrift
-	thrift -r -gen js -out src/imp/platform/browser/thrift_api $(LIGHTSTEP_HOME)/go/src/crouton/crouton.thrift
+	docker run -v "$(LIGHTSTEP_HOME)/go/src/crouton/:/data" -v "$(PWD):/out" --rm thrift:0.9.2 \
+		thrift -r -gen js:node -out /out/src/imp/platform/node/thrift_api /data/crouton.thrift
+	docker run -v "$(LIGHTSTEP_HOME)/go/src/crouton/:/data" -v "$(PWD):/out" --rm thrift:0.9.2 \
+		thrift -r -gen js -out /out/src/imp/platform/browser/thrift_api /data/crouton.thrift
 	rm src/imp/platform/browser/thrift_api/ReportingService.js
 	rm src/imp/platform/node/thrift_api/ReportingService.js
 	npm run thrift-browser


### PR DESCRIPTION
Updates the build steps for generating the LightStep Thrift files to use a Docker image rather than requiring a local copy of Thrift v0.9.2.

FYI @bg451, @djspoons 