### PR TITLE
Fix defect in report of internal metrics

### DIFF
--- a/src/imp/tracer_imp.js
+++ b/src/imp/tracer_imp.js
@@ -688,9 +688,13 @@ export default class TracerImp extends EventEmitter {
         this._spanRecords = [];
         this._internalLogs = [];
 
+        // Create a new object to avoid overwriting the values in any references
+        // to the old object
+        let counters = {};
         for (let key in this._counters) {
-            this._counters[key] = 0;
+            counters[key] = 0;
         }
+        this._counters = counters;
     }
 
     _buffersAreEmpty() {
@@ -967,8 +971,8 @@ export default class TracerImp extends EventEmitter {
                 continue;
             }
             thriftCounters.push(new crouton_thrift.MetricsSample({
-                name  : coerce.toString(key),
-                value : coerce.toNumber(value),
+                name         : coerce.toString(key),
+                double_value : coerce.toNumber(value),
             }));
         }
 


### PR DESCRIPTION
## Summary

Fixes a defect where client library internal metrics were not being reported correctly:

* Counters were being reset on a _reference_ to the not-yet-reported counters map, not a copy (effectively zero'ing out the data before it got reported)
* The wrong thrift field name was being used in the actual report

