### PR TITLE
Handle bad inject format gracefully. Add tests.

### DIFF
--- a/src/imp/tracer_imp.js
+++ b/src/imp/tracer_imp.js
@@ -204,6 +204,15 @@ export default class TracerImp extends EventEmitter {
     }
 
     _injectToTextMap(span, carrier) {
+        if (!carrier) {
+            this._error('Unexpected null FORMAT_TEXT_MAP carrier in call to inject');
+            return;
+        }
+        if (typeof carrier !== 'object') {
+            this._error(`Unexpected '${typeof carrier}' FORMAT_TEXT_MAP carrier in call to inject`);
+            return;
+        }
+
         let baggage = span.getBaggage();
         let traceGUID = span.traceGUID();
 
@@ -1148,7 +1157,7 @@ export default class TracerImp extends EventEmitter {
 
     _pushInternalLog(record) {
         if (this._internalLogs.length >= MAX_INTERNAL_LOGS) {
-            record.message(`MAX_INTERNAL_LOGS limit hit. Last error: ${record.message}`);
+            record.message = `MAX_INTERNAL_LOGS limit hit. Last error: ${record.message}`;
             this._internalLogs[this._internalLogs.length - 1] = record;
         } else {
             this._internalLogs.push(record);

--- a/test/manual/drop_spans/index.js
+++ b/test/manual/drop_spans/index.js
@@ -15,6 +15,12 @@ var parent = Tracer.startSpan('parent');
 for (var i = 0; i < 20000; i++) {
     var child = Tracer.startSpan('child', { parent: parent });
     child.logEvent('log_event');
+
+    // Intentional internal error
+    if (i % 20 === 0) {
+        Tracer.inject(child, "custom_format", []);
+    }
+
     child.finish();
 }
 parent.finish();

--- a/test/suites/common/regress.js
+++ b/test/suites/common/regress.js
@@ -38,3 +38,9 @@ it('should generate correct URLs for both finished and unfinished spans', functi
     expect(url1).to.be.a('string');
     expect(url2).to.be.a('string');
 });
+
+it('should fail gracefully on invalid inject format', function() {
+    var span = Tracer.startSpan('test');
+    Tracer.inject(span, "unknown_custom_format", {});
+    span.finish();
+});


### PR DESCRIPTION
## Summary

* Fix an exception thrown when an unknown format is used in the client lib (internally log the error and continue instead)
* Add a test for the above
* Fix a defect in the internal error handling when the limit is hit