### PR TITLE
Set a default timeout on reports to the collector

### DIFF
--- a/src/imp/tracer_imp.js
+++ b/src/imp/tracer_imp.js
@@ -134,6 +134,7 @@ export default class TracerImp extends EventEmitter {
         this.addOption('max_log_records',       { type: 'int',     defaultValue: 4096 });
         this.addOption('max_span_records',      { type: 'int',     defaultValue: 4096 });
         this.addOption('default_span_tags',     { type: 'any',     defaultValue: {} });
+        this.addOption('report_timeout_millis', { type: 'int',     defaultValue: 5000 });
 
         // Debugging options
         //


### PR DESCRIPTION
Changes the code to explicitly set a socket timeout on internal report requests. 

At the exit of the Node process any remaining buffered data is flushed. The process waits for pending requests; thus, the exceedingly long default timeout of the Node request could in some circumstances cause the process to take a long time to exit - which violates the goal of having the instrumentation library have minimal effect on the host application. A smaller, configurable timeout reduces this effect.

* Adds a 5 second default timeout for report requests
* This is configurable via an unofficial `report_timeout_millis` option ("unofficial" in the sense that this is not part of all LightStep client libraries and is subject to change)
