### PR TITLE
Changes/better error reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # CHANGELOG
 
+*Log of significant changes, especially those affecting the supported API.*
+
+## 0.10.4
+
+* **MINOR API CHANGE**: `verbosity` level semantics updated
+    * `2`: echo all errors (but not warnings and info statements)
+    * `3`: echo all errors, warnings, and info statements
+    * `>3`: same as `3` but will increasing level of detail
+
+## 0.10.3
+
+* Add non-standard option `report_timeout_millis`
+
+## 0.10.2
+
+* Add non-standard option `default_span_tags`
+
 ## 0.10.1
 
 * **API CHANGE**: Option `verbose` renamed to `verbosity`

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ lint:
 	node node_modules/eslint/bin/eslint.js --color src
 
 # Dev convenience for automatically rebuilding on file changes
-watch:
+watch: build
 	node node_modules/watch-trigger/index.js watch-trigger.config.json
 
 update_examples: node_modules

--- a/README.md
+++ b/README.md
@@ -49,8 +49,24 @@ var LightStep = require('lightstep-tracer/browser');
 
 ### tracer(options)
 
+**Required options**
+
 * `access_token` `string` *required* - the project access token
 * `component_name` `string` *required* - the string identifier for the application, service, or process
+
+**Standard options**
+
+* `verbosity` `number` *optional, default=1* - controls the level of logging to the console
+    - `0` - the client library will *never* log to the console
+    - `1` - only the first error encountered will be logged to the console
+    - `2` - all errors are logged to the console
+    - `3` - all errors, warnings, and info statements are logged to the console
+    - `4` - all log statements, including debugging details
+* `collector_host` `string` *optional* - custom collector hostname
+* `collector_port` `number` *optional* - custom collector port
+* `collector_encryption` `string` *optional, default='tls'*
+    - `tls` - use HTTPS encrypted connections
+    - `none` - use HTTP plain-text connections
 
 **Browser-specific initialization options**
 
@@ -60,7 +76,9 @@ var LightStep = require('lightstep-tracer/browser');
 
 * `xhr_url_exclusion_patterns` `RegExp[]` - an array of regular expressions used to exclude URLs from `XMLHttpRequest` auto-instrumentation. The default value is an empty array. For a given URL to be instrumented, it must match at least one regular expression in `xhr_url_inclusion_patterns` and not match any regular expressions in `xhr_url_exclusion_patterns`.
 
-**Non-standard options without no forwards-compatibility implications**
+**Non-standard options**
+
+*NOTE: Future API compatibility on non-standard options is not guaranteed.*
 
 * `default_span_tags` `string` *optional* - an associative array of tags to add to every span started by the tracer (e.g., the active user id in a browser client)
 

--- a/src/imp/platform/node/platform_node.js
+++ b/src/imp/platform/node/platform_node.js
@@ -115,6 +115,9 @@ export default class PlatformNode {
             case '--lightstep-log_to_console=1':
                 opts.log_to_console = true;
                 break;
+            case '--lightstep-verbosity=5':
+                opts.verbosity = 5;
+                break;
             case '--lightstep-verbosity=4':
                 opts.verbosity = 4;
                 break;

--- a/src/imp/platform/node/transport_httpjson.js
+++ b/src/imp/platform/node/transport_httpjson.js
@@ -4,11 +4,6 @@ import http from 'http';
 const kMaxDetailedErrorFrequencyMs = 30000;
 const kMaxStringLength = 2048;
 
-function errorFromResponse(res, buffer) {
-    buffer = `${buffer}`.replace(/\s+$/, '');
-    return new Error(`status code=${res.statusCode}, message='${res.statusMessage}', body='${buffer}'`);
-}
-
 function truncatedString(s) {
     if (s.length <= kMaxStringLength) {
         return s;
@@ -16,6 +11,12 @@ function truncatedString(s) {
     let half = Math.floor(kMaxStringLength / 2);
     return `${s.substr(0, half)}...${s.substr(-half)}`;
 }
+
+function errorFromResponse(res, buffer) {
+    buffer = truncatedString(`${buffer}`.replace(/\s+$/, ''));
+    return new Error(`status code=${res.statusCode}, message='${res.statusMessage}', body='${buffer}'`);
+}
+
 
 export default class TransportHTTPJSON {
     constructor(logger) {

--- a/src/imp/platform/node/transport_httpjson.js
+++ b/src/imp/platform/node/transport_httpjson.js
@@ -96,7 +96,7 @@ export default class TransportHTTPJSON {
         });
         req.on('error', (err) => {
             this._detailedError('HTTP request error', {
-                report : reportRequest,
+                report : truncatedString(payload),
             });
             done(err, null);
         });

--- a/src/imp/platform/node/transport_httpjson.js
+++ b/src/imp/platform/node/transport_httpjson.js
@@ -1,12 +1,31 @@
 import https from 'https';
 import http from 'http';
 
+const kMaxDetailedErrorFrequencyMs = 30000;
+const kMaxStringLength = 2048;
+
+function errorFromResponse(res, buffer) {
+    buffer = `${buffer}`.replace(/\s+$/, '');
+    return new Error(`status code=${res.statusCode}, message='${res.statusMessage}', body='${buffer}'`);
+}
+
+function truncatedString(s) {
+    if (s.length <= kMaxStringLength) {
+        return s;
+    }
+    let half = Math.floor(kMaxStringLength / 2);
+    return `${s.substr(0, half)}...${s.substr(-half)}`;
+}
+
 export default class TransportHTTPJSON {
-    constructor() {
+    constructor(logger) {
         this._host = '';
         this._port = 0;
         this._encryption = '';
         this._timeoutMs = 0;
+
+        this._logger = logger;
+        this._lastErrorMs = 0;
     }
 
     ensureConnection(opts) {
@@ -24,6 +43,17 @@ export default class TransportHTTPJSON {
             path     : '/api/v0/reports',
         };
         let protocol = (this._encryption === 'none') ? http : https;
+
+        let payload;
+        try {
+            payload = JSON.stringify(reportRequest);
+        } catch (exception) {
+            // This should never happen. The library should always be constructing
+            // valid reports.
+            this._error('Could not JSON.stringify report!');
+            return;
+        }
+
         let req = protocol.request(options, (res) => {
             let buffer = '';
             res.on('data', (chunk) => {
@@ -32,8 +62,18 @@ export default class TransportHTTPJSON {
             res.on('end', () => {
                 let err = null;
                 let resp = null;
-                if (res.statusCode !== 200) {
-                    err = new Error(`status code = ${res.statusCode}`);
+                if (res.statusCode === 400) {
+                    this._throttleError(() => {
+                        this._error('transport status code = 400', {
+                            code    : res.statusCode,
+                            message : res.statusMessage,
+                            body    : buffer,
+                            report  : truncatedString(payload),
+                        });
+                    });
+                    err = errorFromResponse(res, buffer);
+                } else if (res.statusCode !== 200) {
+                    err = errorFromResponse(res, buffer);
                 } else if (!buffer) {
                     err = new Error('unexpected empty response');
                 } else {
@@ -55,10 +95,11 @@ export default class TransportHTTPJSON {
             });
         });
         req.on('error', (err) => {
+            this._detailedError('HTTP request error', {
+                report : reportRequest,
+            });
             done(err, null);
         });
-
-        let payload = JSON.stringify(reportRequest);
 
         req.setHeader('Host', this._host);
         req.setHeader('User-Agent', 'LightStep-JavaScript-Node');
@@ -71,5 +112,17 @@ export default class TransportHTTPJSON {
         }
         req.write(payload);
         req.end();
+    }
+
+    _throttleError(f) {
+        let now = Date.now();
+        if (now - this._lastErrorMs < kMaxDetailedErrorFrequencyMs) {
+            return;
+        }
+        this._lastErrorMs = now;
+        f();
+    }
+    _error(msg, payload) {
+        this._logger.error(msg, payload);
     }
 }


### PR DESCRIPTION
## Summary

Improves the error reporting in the JavaScript client library.

* Update `verbosity` semantics so `2` prints all *errors* to the console, but no warnings or info logging
* Ensure the response error message is included in HTTP 400 errors (more specifically, include the truncated HTTP body on any non-200 status code)
* In a throttled fashion, log additional verbose details along with HTTP errors 