### PR TITLE
Changes/unrecognized carrier key

### DIFF
--- a/src/imp/tracer_imp.js
+++ b/src/imp/tracer_imp.js
@@ -267,8 +267,12 @@ export default class TracerImp extends EventEmitter {
                     // new span
                     span.setFields({ parent_guid : value });
                     break;
+                case 'sampled':
+                    // Ignored. The carrier may be coming from a different client
+                    // library that sends this (even though it's not used).
+                    break;
                 default:
-                    this._error('Unrecognized carrier key with recognized prefix. Ignoring.');
+                    this._error(`Unrecognized carrier key '${key}' with recognized prefix. Ignoring.`);
                     break;
                 }
             }

--- a/test/unittest_node.js
+++ b/test/unittest_node.js
@@ -14,6 +14,7 @@ Tracer.initGlobalTracer(LightStep.tracer({
     component_name         : 'lightstep-tracer/unit-tests',
     access_token           : '010101010101010101020101010',
     disable_reporting_loop : true,
+    verbosity              : 0,
 }));
 
 describe('LightStep Tracer', function() {


### PR DESCRIPTION
## Summary

Minor change:

* Fixes a case where an error was being reported for a valid condition (i.e. the `ot-tracer-sampled` carrier key *should* be expected)
* Displays console logging of errors in unit tests as the unit tests intentionally test code paths that generate errors (and the logging is therefore confusing/misleading)