### PR TITLE
Fix call to method that was removed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,9 +67,9 @@ test_browser:
 # different behavior that does not work with the current implementation.
 test_all: build
 	scripts/docker_test.sh latest
+	scripts/docker_test.sh 6.2
 	scripts/docker_test.sh 5.8
 	scripts/docker_test.sh 5.1
-	scripts/docker_test.sh 5.0
 	scripts/docker_test.sh 4.4
 	scripts/docker_test.sh 4.0
 	scripts/docker_test.sh 0.12

--- a/src/imp/platform/node/transport_httpjson.js
+++ b/src/imp/platform/node/transport_httpjson.js
@@ -95,8 +95,10 @@ export default class TransportHTTPJSON {
             });
         });
         req.on('error', (err) => {
-            this._detailedError('HTTP request error', {
-                report : truncatedString(payload),
+            this._throttleError(() => {
+                this._error('HTTP request error', {
+                    report : truncatedString(payload),
+                });
             });
             done(err, null);
         });


### PR DESCRIPTION
Fixes a call to a method that does not exist in one of the error handling paths.  The unit testing does not test this error path so this stale code was not noticed in the previous PR.

(Also updates the unit tests to explicitly test against Node 6.2, but this is unrelated to the defect being fixed.)