### PR TITLE
Add explicit error message when a report times out

### DIFF
--- a/src/imp/tracer_imp.js
+++ b/src/imp/tracer_imp.js
@@ -1007,7 +1007,6 @@ export default class TracerImp extends EventEmitter {
             internal_metrics        : new crouton_thrift.Metrics({
                 counts              : thriftCounters,
             }),
-
             timestamp_offset_micros : timestampOffset,
         });
         this._infoV(5, `timestamp_offset_micros = ${timestampOffset}`);


### PR DESCRIPTION
## Summary

Small change to explicitly include a message that a report timed out. Previously, this could only be inferred based on the code path.