### PR TITLE
Coerce non-string objects to strings when setting operation name

### DIFF
--- a/src/imp/platform/node/transport_httpjson.js
+++ b/src/imp/platform/node/transport_httpjson.js
@@ -13,6 +13,14 @@ function truncatedString(s) {
     return `${s.substr(0, half)}...${s.substr(-half)}`;
 }
 
+function encodeAndTruncate(obj) {
+    try {
+        return truncatedString(JSON.stringify(obj));
+    } catch (exception) {
+        return exception;
+    }
+}
+
 function errorFromResponse(res, buffer) {
     buffer = truncatedString(`${buffer}`.replace(/\s+$/, ''));
     return new Error(`status code=${res.statusCode}, message='${res.statusMessage}', body='${buffer}'`);
@@ -86,7 +94,7 @@ export default class TransportHTTPJSON {
                                 message : res.statusMessage,
                                 body    : buffer,
                                 extra   : extraErrorData,
-                                report  : truncatedString(payload),
+                                report  : encodeAndTruncate(reportRequest),
                             });
                         });
                         err = errorFromResponse(res, buffer);

--- a/src/imp/span_imp.js
+++ b/src/imp/span_imp.js
@@ -17,7 +17,7 @@ export default class SpanImp {
     }
 
     setOperationName(name) {
-        this._operation = name;
+        this._operation = `${name}`;
     }
 
     addTags(keyValuePairs) {

--- a/test/suites/common/regress.js
+++ b/test/suites/common/regress.js
@@ -44,3 +44,23 @@ it('should fail gracefully on invalid inject format', function() {
     Tracer.inject(span.context(), "unknown_custom_format", {});
     span.finish();
 });
+
+it('should coerce non-string operation names to strings', function() {
+    var cases = [
+        'test', 42, true
+    ];
+    var i;
+    for (i = 0; i < cases.length; i++) {
+        var span = Tracer.startSpan(cases[i]);
+        var name = span.imp().getOperationName();
+        expect(name).to.be.a('string');
+        span.finish();
+    }
+    for (i = 0; i < cases.length; i++) {
+        var span = Tracer.startSpan('valid_name');
+        span.setOperationName(cases[i]);
+        var name = span.imp().getOperationName();
+        expect(name).to.be.a('string');
+        span.finish();
+    }
+});


### PR DESCRIPTION
## Summary

Addresses a problem where `number` operation name would cause reports to fail as a `string` was expected.  The fix was to coerce types to strings when the operation name is set.

* Coerce the argument to `setOperationName` to a `string`
* Add a regression test for the case that was causing an error
* Fix a problem in the internal error reporting where the gzipped report was displayed rather than the source report