### PR TITLE
Add beginMicros / endMicros to SpanImp

### DIFF
--- a/src/imp/span_imp.js
+++ b/src/imp/span_imp.js
@@ -119,9 +119,17 @@ export default class SpanImp {
         return this;
     }
 
+    beginMicros() {
+        return this._beginMicros;
+    }
+
     setBeginMicros(micros) {
         this._beginMicros = micros;
         return this;
+    }
+
+    endMicros() {
+        return this._endMicros;
     }
 
     setEndMicros(micros) {

--- a/test/suites/common/span_imp.js
+++ b/test/suites/common/span_imp.js
@@ -16,11 +16,27 @@ describe("SpanImp", function() {
         });
     });
 
+    describe("SpanImp#beginMicros", function() {
+        it("returns a number", function() {
+            var span = Tracer.startSpan('test');
+            expect(span.imp().beginMicros()).to.be.a("number");
+            span.finish();
+        });
+    });
+
     // Used by the browser to create spans retroactively
     describe("SpanImp#setEndMicros", function() {
         it("is a method", function() {
             var span = Tracer.startSpan('test');
             expect(span.imp().setEndMicros).to.be.a("function");
+            span.finish();
+        });
+    });
+
+    describe("SpanImp#endMicros", function() {
+        it("returns a number", function() {
+            var span = Tracer.startSpan('test');
+            expect(span.imp().endMicros()).to.be.a("number");
             span.finish();
         });
     });


### PR DESCRIPTION
## Summary

Adds a few internal-use methods needed to create spans retroactively.  These are not part of the OpenTracing API and not intended for public use.

* Adds `beginMicros` to `SpanImp`
* Adds `endMicros` to `SpanImp`