### PR TITLE
Add error message if log() is passed an incorrect data type

### DIFF
--- a/src/imp/span_imp.js
+++ b/src/imp/span_imp.js
@@ -39,6 +39,12 @@ export default class SpanImp {
      */
     // Log record specified by fields
     log(fields) {
+        const argumentType = typeof fields;
+        if (argumentType !== 'string') {
+            this._tracer._error('Span.log() expects an object as its argument');
+            return;
+        }
+
         let rec = this._tracer.log()
             .span(this.guid())
             .level(constants.LOG_STRING_TO_LEVEL[fields.level] || constants.LOG_INFO);


### PR DESCRIPTION
## Summary

Simple change to generate an internal error log if the `Span.log()` method is called with a string rather than object argument (which seems like a potentially common mistake).

Note: the OpenTracing spec doesn't appear to formally define the signature of log(). The argument as an object is following the convention of the Python library.