### PR TITLE
Use Math.random(), not crypto.randomBytes for GUIDs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,11 +42,14 @@ publish: test test_all coverage
 # NOTE: the benchmark package is *not* part of package.json as it relies on a
 # native module -- that does not compile on all systems. Until/unless that is
 # resolved, it gets "manually" installed here when the benchmarks are run
-benchmark: node_modules/sc-benchmark
-	node benchmarks/benchmark.js
+#
+# NOTE: the --max-old-space-size=4000 works around what appears to be a defect
+# in Node 6.x
+benchmark: build node_modules/sc-benchmark
+	node --max-old-space-size=4000 benchmarks/benchmark.js
 
 node_modules/sc-benchmark:
-	npm install sc-benchmark@0.1.4
+	npm install sc-benchmark@0.1.11
 
 test: build test_node test_browser lint
 

--- a/benchmarks/benchmark.js
+++ b/benchmarks/benchmark.js
@@ -13,6 +13,8 @@ function createNonReportingTracer() {
         component_name         : 'lightstep-tracer/benchmarks',
         access_token           : 'unused',
         disable_reporting_loop : true,
+        disable_report_on_exit : true,
+        collector_host         : 'example.com',
     }));
 }
 function createNestedObject(n) {
@@ -39,6 +41,26 @@ let s = new Suite();
 s.bench('sanity check (10ms)', (N, t) => {
     for (let i = 0; i < N; i++) {
         busyWait(10.0);
+    }
+});
+
+s.bench('uuid w/ crypto.randomBytes', (N, t) => {
+    for (let i = 0; i < N; i++) {
+        let a = new Array(1000);
+        for (let j = 0; j < a.length; j++) {
+            a[j] = require('crypto').randomBytes(8).toString('hex');
+        }
+    }
+});
+
+s.bench('uuid w/ Math.random()', (N, t) => {
+    for (let i = 0; i < N; i++) {
+        let a = new Array(1000);
+        for (let j = 0; j < a.length; j++) {
+            let p0 = `00000000${((Math.random() * 0xFFFFFFFF)|0).toString(16)}`.substr(-8);
+            let p1 = `00000000${((Math.random() * 0xFFFFFFFF)|0).toString(16)}`.substr(-8);
+            a[j] = `${p0}${p1}`;
+        }
     }
 });
 

--- a/src/imp/platform/node/platform_node.js
+++ b/src/imp/platform/node/platform_node.js
@@ -88,7 +88,9 @@ export default class PlatformNode {
     }
 
     generateUUID() {
-        return require('crypto').randomBytes(8).toString('hex');
+        let p0 = `00000000${((Math.random() * 0xFFFFFFFF)|0).toString(16)}`.substr(-8);
+        let p1 = `00000000${((Math.random() * 0xFFFFFFFF)|0).toString(16)}`.substr(-8);
+        return `${p0}${p1}`;
     }
 
     onBeforeExit(...args) {


### PR DESCRIPTION
## Summary

Replaces the Node.js GUID generation function to be based on `Math.random()` rather than `crypto.randomBytes()`. Cryptographically strong random numbers are, as a generalization, more work to compute and overkill for the internal GUIDs used by LightStep.

I'm not putting too much weight into the numbers since they're based on synthetic microbenchmarks, but it seems the all the span-related `make benchmark` numbers are consistently faster after this change, with a conservative guess of about a 2x improvement for a raw loop of starting and finishing empty spans (again, not a real world benchmark, but seems reasonably safe to say this is an improvement).

Thanks to @emmettnicholas for pointing out the inefficiency!
