### PR TITLE
Replace or protect all for-in loops.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,7 +10,7 @@
       "key-spacing": [2, { "align": "colon", "beforeColon": true, "afterColon": true }],
       "prefer-const": [0],
       "object-shorthand": [2, "never" ],
-      "guard-for-in": [0],
+      "guard-for-in": [2],
       "no-param-reassign": [0],
       "max-len": [2, 120, 4],
       "prefer-rest-params" : [0],

--- a/src/_each.js
+++ b/src/_each.js
@@ -1,0 +1,14 @@
+// Underscore.js-like wrapper to iterate for keys. Note that even for completely
+// internal objects, packages may modify default Object prototypes and properties
+// (e.g. Ember.js) so it's almost never safe to assume a particular object can
+// iterated with for-in.
+export default function _each(obj, cb) {
+    if (!obj) {
+        return;
+    }
+    for (let key in obj) {
+        if (obj.hasOwnProperty(key)) {
+            cb(obj[key], key);
+        }
+    }
+}

--- a/src/_each.js
+++ b/src/_each.js
@@ -1,4 +1,4 @@
-// Underscore.js-like wrapper to iterate for keys. Note that even for completely
+// Underscore.js-like wrapper to iterate object key-values. Note that even for completely
 // internal objects, packages may modify default Object prototypes and properties
 // (e.g. Ember.js) so it's almost never safe to assume a particular object can
 // iterated with for-in.

--- a/src/imp/globals.js
+++ b/src/imp/globals.js
@@ -1,12 +1,14 @@
+import _each from '../_each';
+
 class PackageGlobals {
     constructor() {
         this.options = {};
     }
 
     setOptions(opts) {
-        for (let key in opts) {
-            this.options[key] = opts[key];
-        }
+        _each(opts, (val, key) => {
+            this.options[key] = val;
+        });
     }
 }
 

--- a/src/imp/platform/node/platform_node.js
+++ b/src/imp/platform/node/platform_node.js
@@ -1,4 +1,5 @@
 const os = require('os');
+const _each = require('../../../_each.js');
 
 function computeStartMicros() {
     let startTimeMs = Date.now();
@@ -106,9 +107,7 @@ export default class PlatformNode {
             return;
         }
         let opts = {};
-        for (let key in process.argv) {
-            const value = process.argv[key];
-
+        _each(process.argv, (value, key) => {
             // Keep the argument "parsing" simple.  These are primarily debug
             // options regardless.
             switch (value.toLowerCase()) {
@@ -136,7 +135,7 @@ export default class PlatformNode {
                 // Ignore
                 break;
             }
-        }
+        });
         return opts;
     }
 

--- a/src/imp/span_context_imp.js
+++ b/src/imp/span_context_imp.js
@@ -1,3 +1,5 @@
+import _each from '../_each';
+
 export default class SpanContextImp {
 
     // ---------------------------------------------------------------------- //
@@ -21,9 +23,9 @@ export default class SpanContextImp {
     //
     // https://github.com/opentracing/opentracing.github.io/issues/103
     forEachBaggageItem(f) {
-        for (let key in this._baggage) {
-            f(key, this._baggage[key]);
-        }
+        _each(this._baggage, (val, key) => {
+            f(key, val);
+        });
     }
 
     // ---------------------------------------------------------------------- //

--- a/src/imp/util/clock_state.js
+++ b/src/imp/util/clock_state.js
@@ -1,3 +1,5 @@
+import _each from '../../_each';
+
 // How many updates before a sample is considered old. This happens to
 // be one less than the number of samples in our buffer but that's
 // somewhat arbitrary.
@@ -94,13 +96,12 @@ class ClockState {
         // offset is the "best" one.
         let minDelayMicros = Number.MAX_VALUE;
         let bestOffsetMicros = 0;
-        for (let key in this._samples) {
-            const sample = this._samples[key];
+        _each(this._samples, (sample) => {
             if (sample.delayMicros < minDelayMicros) {
                 minDelayMicros = sample.delayMicros;
                 bestOffsetMicros = sample.offsetMicros;
             }
-        }
+        });
 
         // No update.
         if (bestOffsetMicros === this._currentOffsetMicros) {
@@ -110,10 +111,9 @@ class ClockState {
         // Now compute the jitter, i.e. the error relative to the new
         // offset were we to use it.
         let jitter = 0;
-        for (let key in this._samples) {
-            const sample = this._samples[key];
+        _each(this._samples, (sample) => {
             jitter += Math.pow(bestOffsetMicros - sample.offsetMicros, 2);
-        }
+        });
         jitter = Math.sqrt(jitter / this._samples.length);
 
         // Ignore spikes: only use the new offset if the change is not too

--- a/src/lib.js
+++ b/src/lib.js
@@ -2,6 +2,7 @@ import globals from './imp/globals';
 import * as Constants from './constants';
 import TracerImp from './imp/tracer_imp';
 import { Platform } from './platform_abstraction_layer';
+import _each from './_each';
 
 class Library {
 
@@ -9,9 +10,9 @@ class Library {
         this._singleton = null;
 
         // Make the constants accessible off the LightStep object
-        for (let key in Constants) {
-            this[key] = this[key] || Constants[key];
-        }
+        _each(Constants, (val, key) => {
+            this[key] = val;
+        });
     }
 
     /**

--- a/src/plugins/instrument_document_load.js
+++ b/src/plugins/instrument_document_load.js
@@ -1,3 +1,5 @@
+import _each from '../_each';
+
 class InstrumentPageLoad {
     constructor() {
         this._inited = false;
@@ -63,7 +65,7 @@ class InstrumentPageLoad {
 
     _copyNavigatorProperties(nav) {
         let dst = {};
-        for (let key in nav) {
+        for (let key in nav) { // eslint-disable-line guard-for-in
             try {
                 let value = nav[key];
                 switch (key) {
@@ -114,12 +116,10 @@ class InstrumentPageLoad {
 
         parent.setTag('user_agent', navigator.userAgent);
 
-        for (let key in timing) {
-            let value = timing[key];
-
+        _each(timing, (value, key) => {
             // e.g. secureConnectionStart is not always set
             if (typeof value !== 'number' || value === 0) {
-                continue;
+                return;
             }
 
             let micros = value * 1000.0;
@@ -135,7 +135,7 @@ class InstrumentPageLoad {
                 timestamp_micros : micros,
                 payload          : payload,
             });
-        }
+        });
 
         if (window.chrome && window.chrome.loadTimes) {
             let chromeTimes = window.chrome.loadTimes();

--- a/src/plugins/instrument_xhr.js
+++ b/src/plugins/instrument_xhr.js
@@ -1,3 +1,5 @@
+import _each from '../_each';
+
 // Capture the proxied values on script load (i.e. ASAP) in case there are
 // multiple layers of instrumentation.
 let proxied = {};
@@ -38,7 +40,7 @@ function getCookies() {
 function getResponseHeaders(xhr) {
     let raw = xhr.getAllResponseHeaders();
     let parts = raw.replace(/\s+$/, '').split(/\n/);
-    for (let i in parts) {
+    for (let i = 0; i < parts.length; i++) {
         parts[i] = parts[i].replace(/\r/g, '').replace(/^\s+/, '').replace(/\s+$/, '');
     }
     return parts;
@@ -194,9 +196,9 @@ class InstrumentXHR {
             }
 
             let openPayload = {};
-            for (let key in tags) {
-                openPayload[key] = tags[key];
-            }
+            _each(tags, (val, key) => {
+                openPayload[key] = val;
+            });
             openPayload.cookies = getCookies();
 
             // Note: async defaults to true
@@ -319,6 +321,9 @@ class InstrumentXHR {
             return false;
         }
         for (let key in this._internalExclusions) {
+            if (!opts._internalExclusions.hasOwnProperty(key)) {
+                continue;
+            }
             const ex = this._internalExclusions[key];
             if (ex.test(url)) {
                 return false;
@@ -326,6 +331,9 @@ class InstrumentXHR {
         }
         let include = false;
         for (let key in opts.xhr_url_inclusion_patterns) {
+            if (!opts.xhr_url_inclusion_patterns.hasOwnProperty(key)) {
+                continue;
+            }
             const inc = opts.xhr_url_inclusion_patterns[key];
             if (inc.test(url)) {
                 include = true;
@@ -336,6 +344,9 @@ class InstrumentXHR {
             return false;
         }
         for (let key in opts.xhr_url_exclusion_patterns) {
+            if (!opts.xhr_url_exclusion_patterns.hasOwnProperty(key)) {
+                continue;
+            }
             const ex = opts.xhr_url_exclusion_patterns[key];
             if (ex.test(url)) {
                 return false;


### PR DESCRIPTION
## Summary

Fixes an issue where internal use of `for (k in obj)` was causing problems with [frameworks that extend native object prototypes](https://guides.emberjs.com/v2.3.0/configuring-ember/disabling-prototype-extensions/).

Changes:

* Enable the `guard-for-in` eslint rule to avoid future regressions
* Add a helper `_each` to safely iterate over object properties
* Replace (almost) all `for (k in obj)` instances with `_each`
* Replace a few `for in` instances with a `hasOwnProperties` where that was easier due to early return branching