### PR TITLE
Defect/payload not valid string

### DIFF
--- a/src/imp/platform/node/transport_httpjson.js
+++ b/src/imp/platform/node/transport_httpjson.js
@@ -6,7 +6,7 @@ const kMaxDetailedErrorFrequencyMs = 30000;
 const kMaxStringLength = 2048;
 
 function truncatedString(s) {
-    if (s.length <= kMaxStringLength) {
+    if (!s || s.length <= kMaxStringLength) {
         return s;
     }
     let half = Math.floor(kMaxStringLength / 2);
@@ -22,7 +22,9 @@ function encodeAndTruncate(obj) {
 }
 
 function errorFromResponse(res, buffer) {
-    buffer = truncatedString(`${buffer}`.replace(/\s+$/, ''));
+    if (buffer && buffer.length) {
+        buffer = truncatedString(`${buffer}`.replace(/\s+$/, ''));
+    }
     return new Error(`status code=${res.statusCode}, message='${res.statusMessage}', body='${buffer}'`);
 }
 

--- a/src/imp/platform/node/transport_httpjson.js
+++ b/src/imp/platform/node/transport_httpjson.js
@@ -128,7 +128,7 @@ export default class TransportHTTPJSON {
                     this._error('HTTP request error', {
                         error  : err,
                         extra  : extraErrorData,
-                        report : truncatedString(payload),
+                        report : encodeAndTruncate(reportRequest),
                     });
                 });
                 done(err, null);


### PR DESCRIPTION
## Summary

Fixes a regression introduced when the reporting was updated to support gzipped payloads. The error handling was still assuming the payload would always be a string.  The error handling now always uses the pre-encoded report -- and some additional precautionary checks against unexpected objects have been added for robustness.

Fixes #68 