### PR TITLE
Ensure negative UUIDs are not generated

### DIFF
--- a/src/imp/platform/browser/platform_browser.js
+++ b/src/imp/platform/browser/platform_browser.js
@@ -58,12 +58,9 @@ class PlatformBrowser {
     }
 
     _generateLongUUID() {
-        let a = Math.floor(Math.random() * 0xFFFFFFFF).toString(16);
-        let b = Math.floor(Math.random() * 0xFFFFFFFF).toString(16);
-        while (b.length < 8) {
-            b = `0${b}`;
-        }
-        return a + b;
+        let p0 = `00000000${Math.abs((Math.random() * 0xFFFFFFFF) | 0).toString(16)}`.substr(-8);
+        let p1 = `00000000${Math.abs((Math.random() * 0xFFFFFFFF) | 0).toString(16)}`.substr(-8);
+        return `${p0}${p1}`;
     }
 
     onBeforeExit(...args) {

--- a/src/imp/platform/node/platform_node.js
+++ b/src/imp/platform/node/platform_node.js
@@ -89,8 +89,8 @@ export default class PlatformNode {
     }
 
     generateUUID() {
-        let p0 = `00000000${((Math.random() * 0xFFFFFFFF) | 0).toString(16)}`.substr(-8);
-        let p1 = `00000000${((Math.random() * 0xFFFFFFFF) | 0).toString(16)}`.substr(-8);
+        let p0 = `00000000${Math.abs((Math.random() * 0xFFFFFFFF) | 0).toString(16)}`.substr(-8);
+        let p1 = `00000000${Math.abs((Math.random() * 0xFFFFFFFF) | 0).toString(16)}`.substr(-8);
         return `${p0}${p1}`;
     }
 

--- a/test/suites/common/span_imp.js
+++ b/test/suites/common/span_imp.js
@@ -47,6 +47,23 @@ describe("SpanImp", function() {
             expect(span.imp().guid).to.be.a("function");
             span.finish();
         });
+
+        it("is a valid 64-bit hex UUID", function() {
+            for (var i = 0; i < 256; i++) {
+                var span = Tracer.startSpan('test');
+                var guid = span.imp().guid();
+                expect(guid).to.be.a('string');
+                expect(guid.length).to.eq(16);
+                var c = guid.split('');
+                expect(c.length).to.eq(16);
+                for (var j = 0; j < 16; j++) {
+                    var v = parseInt(c[j], 16);
+                    expect(v).to.be.gte(0);
+                    expect(v).to.be.lte(15);
+                }
+                span.finish();
+            }
+        });
     });
 
     describe("SpanImp#parentGUID", function() {


### PR DESCRIPTION
## Summary

Fixes a defect where the UUIDs generated for spans could be negative. This was not actually a significant issue as the value simply needs to be unique, but was unexpected behavior.

Also adds a unit test to ensure the UUIDs are in the expected 64-bit hex string format.