### PR TITLE
Defect/platform tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 *Log of significant changes, especially those affecting the supported API.*
 
+## 0.11.17
+
+* Update the internal, automatic tracer tags to follow the convention of using a `lightstep.*` prefix
+
 ## 0.11.16
 
 * Option `verbosity=1` will now throttle the error logging to the first error per minute

--- a/src/imp/platform/browser/platform_browser.js
+++ b/src/imp/platform/browser/platform_browser.js
@@ -103,7 +103,7 @@ class PlatformBrowser {
 
     tracerTags() {
         return {
-            lightstep_tracer_platform : 'browser',
+            'lightstep.tracer_platform' : 'browser',
         };
     }
 

--- a/src/imp/platform/node/platform_node.js
+++ b/src/imp/platform/node/platform_node.js
@@ -141,17 +141,17 @@ export default class PlatformNode {
 
     tracerTags() {
         let tags = {
-            lightstep_tracer_platform : 'node',
-            node_version              : process.version,
-            node_platform             : process.platform,
-            node_arch                 : process.arch,
-            hostname                  : os.hostname(),
+            'lightstep.tracer_platform'         : 'node',
+            'lightstep.tracer_platform_version' : process.version,
+            'lightstep.node_platform'           : process.platform,
+            'lightstep.node_arch'               : process.arch,
+            'lightstep.hostname'                : os.hostname(),
         };
         if (process.argv) {
-            tags.command_line = process.argv.join(' ');
+            tags['lightstep.command_line'] = process.argv.join(' ');
         }
-        if (process.execArgv) {
-            tags.node_arguments = process.execArgv.join(' ');
+        if (process.execArgv && process.execArgv.length > 0) {
+            tags['lightstep.node_arguments'] = process.execArgv.join(' ');
         }
 
         return tags;

--- a/src/imp/tracer_imp.js
+++ b/src/imp/tracer_imp.js
@@ -596,7 +596,7 @@ export default class TracerImp extends EventEmitter {
                 }
                 tags[key] = value;
             });
-            tags.lightstep_tracer_version = packageObject.version;
+            tags['lightstep.tracer_version'] = packageObject.version;
             let platformTags = this._platform.tracerTags();
             _each(platformTags, (val, key) => {
                 tags[key] = val;


### PR DESCRIPTION
## Summary

Normalizes the internal, automatic tracer tags to all use the `lightstep.*` prefix.  This change has no impact on the external API.