### PR TITLE
Update proxy example

### DIFF
--- a/examples/node/package.json
+++ b/examples/node/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "main": "index.js",
   "dependencies": {
-    "opentracing": "*"
+    "opentracing": "0.11.x"
   }
 }

--- a/examples/proxy/index.js
+++ b/examples/proxy/index.js
@@ -42,7 +42,7 @@ var server = http.createServer(function (req, res) {
         var key = req.rawHeaders[i];
         var value = req.rawHeaders[i+1];
         requestHeaders[key] = value;
-        if (key == 'LightStep-Access-Token') {
+        if (key.toLowerCase() === 'lightStep-access-token') {
             accessToken = value;
         }
     }
@@ -60,7 +60,9 @@ var server = http.createServer(function (req, res) {
     // The span "carrier" data is presumed to have been transmitted interleaved
     // among the other HTTP headers.  join() is presumed to ignore unrecognized
     // keys in the map.
-    var span = tracer.join('request_proxy', OpenTracing.FORMAT_TEXT_MAP, requestHeaders);
+
+    var ctx = tracer.extract(OpenTracing.FORMAT_TEXT_MAP, requestHeaders);
+    var span = tracer.startSpan('request_proxy', { childOf : ctx });
     var options = {
         host: 'api.github.com',
         path: req.url + githubAuth,

--- a/examples/proxy/package.json
+++ b/examples/proxy/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "dependencies": {
     "lightstep-tracer": "*",
-    "opentracing": "*"
+    "opentracing": "0.11.x"
   },
   "scripts":{
     "forever" : "forever start --append -l forever.log -o out.log -e err.log index.js"


### PR DESCRIPTION
## Summary

Small update to the examples.  

* Lock the proxy & node examples to a specific minor version of OpenTracing for API compatibility reasons
* Use inject/extract (instead of inject/join) in the proxy example
* Make header checks case insensitive