### PR TITLE
Fix relative include

### DIFF
--- a/test/unittest_node.js
+++ b/test/unittest_node.js
@@ -1,7 +1,7 @@
 // For the convenience of unit testing, add these to the global namespace
 global._ = require('underscore');
 global.expect = require('chai').expect;
-global.opentracing = require('../../opentracing-javascript/lib');
+global.opentracing = require('opentracing');
 global.util = require('./util/util');
 global.requireES6 = requireES6;
 global.lightstep = require('..');


### PR DESCRIPTION
This addresses https://circleci.com/gh/lightstep/lightstep-tracer-javascript/296#tests/containers/0

I had been doing some development locally and (obviously) missed this in my self-review.