### PR TITLE
LS-1991 | instrument page load optional in js client lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ The OpenTracing standard JavaScript API is [documented here](https://doc.esdoc.o
 
 **Browser-specific initialization options**
 
+* `instrument_page_load` `bool` - The functionality works for short-page visits in a "traditional" multi-page website. However, for a single-page web app where a visit to a single "page" can creates a long-lived single span for the entire session. False: automatic disables instrumentation. Defaults to true. This must be set at initialization, changes after initialization will have no effect.
+
 * `xhr_instrumentation` `bool` - if false, disables automatic instrumentation of XMLHttpRequests (XHRs). This must be set at initialization; changes after initialization will have no effect. Defaults to false.  
 
 * `xhr_url_inclusion_patterns` `RegExp[]` - an array of regular expressions used to whitelist URLs for `XMLHttpRequest` auto-instrumentation. The default value is wildcard matching all strings. For a given URL to be instrumented, it must match at least one regular expression in `xhr_url_inclusion_patterns` and not match any regular expressions in `xhr_url_exclusion_patterns`.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The OpenTracing standard JavaScript API is [documented here](https://doc.esdoc.o
 
 **Browser-specific initialization options**
 
-* `instrument_page_load` `bool` - The functionality works for short-page visits in a "traditional" multi-page website. However, for a single-page web app where a visit to a single "page" can creates a long-lived single span for the entire session. False: automatic disables instrumentation. Defaults to true. This must be set at initialization, changes after initialization will have no effect.
+* `instrument_page_load` `bool` - creates a long-lived single span for the entire session and recommended for short-page visits in a "traditional" multi-page website. However, for a single-page web app where a visit to a single "page" can creates a wrong single span it's recommend to disable it. False: automatic disables instrumentation. Defaults to true. This must be set at initialization, changes after initialization will have no effect.
 
 * `xhr_instrumentation` `bool` - if false, disables automatic instrumentation of XMLHttpRequests (XHRs). This must be set at initialization; changes after initialization will have no effect. Defaults to false.  
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The OpenTracing standard JavaScript API is [documented here](https://doc.esdoc.o
 
 **Browser-specific initialization options**
 
-* `instrument_page_load` `bool` - creates a long-lived single span for the entire session and recommended for short-page visits in a "traditional" multi-page website. However, for a single-page web app where a visit to a single "page" can creates a wrong single span it's recommend to disable it. False: automatic disables instrumentation. Defaults to true. This must be set at initialization, changes after initialization will have no effect.
+* `instrument_page_load` `bool` - creates a long-lived single span for the entire page view and is recommended for short-page visits in a multi-page website. For a single-page web app, this behavior may be undesirable. Defaults to true. This must be set at initialization, changes after initialization will have no effect.
 
 * `xhr_instrumentation` `bool` - if false, disables automatic instrumentation of XMLHttpRequests (XHRs). This must be set at initialization; changes after initialization will have no effect. Defaults to false.  
 

--- a/src/imp/platform/browser/options_parser.js
+++ b/src/imp/platform/browser/options_parser.js
@@ -91,9 +91,12 @@ module.exports.parseScriptElementOptions = function (opts, browserOpts) {
 
     // NOTE: this is a little inelegant as this is hard-coding support for a
     // "plug-in" option.
-    let xhrInstrumentation = dataset.xhr_instrumentation;
-    if (typeof xhrInstrumentation === 'string' && xhrInstrumentation === 'true') {
+    if (typeof dataset.xhr_instrumentation === 'string' && dataset.xhr_instrumentation === 'true') {
         opts.xhr_instrumentation = true;
+    }
+
+    if (typeof dataset.instrument_page_load === 'string' && dataset.instrument_page_load === 'true') {
+        opts.instrument_page_load = true;
     }
 };
 

--- a/src/plugins/instrument_document_load.js
+++ b/src/plugins/instrument_document_load.js
@@ -11,6 +11,7 @@ class InstrumentPageLoad {
     }
 
     addOptions(tracerImp) {
+        tracerImp.addOption('instrument_page_load', { type : 'bool', defaultValue : true });
     }
 
     start(tracerImp) {
@@ -22,8 +23,12 @@ class InstrumentPageLoad {
         if (typeof window !== 'object' || typeof document !== 'object') {
             return;
         }
-        this._ensureSpanStarted(tracerImp);
-        document.addEventListener('readystatechange', this._handleReadyStateChange.bind(this));
+
+        const currentOptions = tracerImp.options();
+        if (currentOptions.instrument_page_load) {
+            this._ensureSpanStarted(tracerImp);
+            document.addEventListener('readystatechange', this._handleReadyStateChange.bind(this));
+        }
     }
 
     stop() {


### PR DESCRIPTION
The lightstep-tracer-javascript client library always enables the "InstrumentPageLoad" plug-in. There should be an option for turning this functionality off. (It should likely remain on by default to not break backward compatibility.)

The functionality is okay for short-page visits in a "traditional" multi-page website. However, it is not helpful on a single-page webapp where a visit to a single "page" can span the entire user session. This creates a long-lived single span for the entire session which (for various reasons) does not currently work well with LightStep.

https://lightstep.atlassian.net/browse/LS-1991

@bcronin Im not sure about the comments in README file.