### PR TITLE
LS-5332: Add missing span.finish() call to Browser example

### DIFF
--- a/examples/browser/browser.html
+++ b/examples/browser/browser.html
@@ -85,6 +85,7 @@
                 span.log({ event : 'request_finished', response_body : json });
                 results.value = JSON.stringify(json);
             });
+            span.finish();
         }
 
         function hitEndpoint(parentSpan, callback) {


### PR DESCRIPTION
without this there are no example spans that have parent/child
relationship.