### PR TITLE
[Skyscnnr_OP-99] LightStep Error When Verbosity >= 4 During Report Flush

### DIFF
--- a/src/imp/tracer_imp.js
+++ b/src/imp/tracer_imp.js
@@ -1097,7 +1097,7 @@ export default class Tracer extends opentracing.Tracer {
             } else {
                 if (this.verbosity() >= 4) {
                     this._debug(`Report flushed for last ${reportWindowSeconds} seconds`, {
-                        spans_reported : report.span_records.length,
+                        spans_reported : report.getSpanRecords().length,
                     });
                 }
 


### PR DESCRIPTION
* updates `tracer_imp.js` to use get span records method instead of incorrect object property