### PR TITLE
Fix `make test` from clean machine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ test-node:
 .PHONY: test-browser
 test-browser:
 	cp dist/lightstep-tracer.js test/dist
-	cd test && node ../node_modules/webpack/bin/webpack.js unittest_browser.js dist/unittest_browser.bundle.js
+	cd test && node ../node_modules/webpack/bin/webpack.js unittest_browser.js -o dist/unittest_browser.bundle.js
 	cd test && open unittest.html
 
 # Note: versions < 0.12 are *not* supported.  The 'beforeExit' event has


### PR DESCRIPTION
This broke when we upgrade to webpack 4.