### PR TITLE
Fixes empty error object in logs

### DIFF
--- a/src/imp/log_record_imp.js
+++ b/src/imp/log_record_imp.js
@@ -8,8 +8,8 @@ export default class LogRecordImp {
     constructor(logFieldKeyHardLimit, logFieldValueHardLimit, timestampMicros, fields) {
         if (fields instanceof Error) {
             fields = {
-                'message': fields.message,
-                'stack': fields.stack,
+                stack   : fields.stack,
+                message : fields.message,
             };
         }
 

--- a/src/imp/log_record_imp.js
+++ b/src/imp/log_record_imp.js
@@ -6,6 +6,13 @@ let googleProtobufTimestampPB = require('google-protobuf/google/protobuf/timesta
 
 export default class LogRecordImp {
     constructor(logFieldKeyHardLimit, logFieldValueHardLimit, timestampMicros, fields) {
+        if (fields instanceof Error) {
+            fields = {
+                'message': fields.message,
+                'stack': fields.stack,
+            };
+        }
+
         this._logFieldKeyHardLimit = logFieldKeyHardLimit;
         this._logFieldValueHardLimit = logFieldValueHardLimit;
         this._timestampMicros = timestampMicros;
@@ -59,7 +66,14 @@ export default class LogRecordImp {
 
     getFieldValue(value) {
         let valStr = null;
-        if (value instanceof Object) {
+        if (value instanceof Error) {
+            try {
+                // https://stackoverflow.com/a/26199752/9778850
+                valStr = JSON.stringify(value, Object.getOwnPropertyNames(value));
+            } catch (e) {
+                valStr = `Could not encode value. Exception: ${e}`;
+            }
+        } else if (value instanceof Object) {
             try {
                 valStr = JSON.stringify(value, null, '  ');
             } catch (e) {


### PR DESCRIPTION
A fix for #86.

When the log field is an error, we go ahead and convert it
to a normal object. Otherwise, we use json.Stringify if it's a value for
kv pair. The reason for the two different behaviors is we expect `_fields`
to be iterable, so converting the error to a standard object gives us that
property. If the error is a value in an object, we can safely convert it to a
JSON string. 

Example of logging an error two separate ways:
```javascript
var e = new Error("lorem ipsum 123");

var span = tracer.startSpan('trivial_span');
span.log({
    error    : e,
});
span.log(e);
span.finish();
```

In devmode:
<img width="600" alt="Screen Shot 2019-04-29 at 3 09 01 PM" src="https://user-images.githubusercontent.com/1350653/56930447-8d9a1b80-6a91-11e9-9cd0-65659e0edb96.png">

In trace page:
<img width="463" alt="Screen Shot 2019-04-29 at 3 09 08 PM" src="https://user-images.githubusercontent.com/1350653/56930455-95f25680-6a91-11e9-930a-676d57e86dd9.png">
