### PR TITLE
Minor: Remove deprecated chrome.loadTimes() code

### DIFF
--- a/src/plugins/instrument_document_load.js
+++ b/src/plugins/instrument_document_load.js
@@ -138,16 +138,6 @@ class InstrumentPageLoad {
             }, value);
         });
 
-        if (window.chrome && window.chrome.loadTimes) {
-            let chromeTimes = window.chrome.loadTimes();
-            if (chromeTimes) {
-                parentImp.log({
-                    message : 'window.chrome.loadTimes()',
-                    payload : chromeTimes,
-                }, timing.domComplete);
-            }
-        }
-
         parentImp.setBeginMicros(timing.navigationStart * 1000.0);
 
         parentImp.tracer().startSpan('document/time_to_first_byte', { childOf : parentImp })


### PR DESCRIPTION
This code predates the `window.performance` API, so it makes sense to remove it given that the [`window.performance` API has broad adoption](https://caniuse.com/#feat=nav-timing). 

The `chrome.loadTimes()` code produces console warnings for most Chrome users, since it's deprecated; this PR eliminates that.