### PR TITLE
Add browser field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "lightstep-tracer",
   "version": "0.21.1",
   "main": "index.js",
+  "browser": "browser.js",
   "engines": {
     "node": ">=0.12.0"
   },


### PR DESCRIPTION
The browser field provides as a hint to bundlers when packaging this library. This lets isomorphic applications import this library using the same import path in both the browser bundle and in Node, which is useful when the target environment is not known.