### PR TITLE
LS-10207: Fixes crashes when a bad response is returned

### DIFF
--- a/src/imp/platform/node/transport_httpproto.js
+++ b/src/imp/platform/node/transport_httpproto.js
@@ -106,12 +106,12 @@ export default class TransportHTTPProto {
                         err = new Error('unexpected empty response');
                     } else {
                         try {
-                            resp = proto.ReportResponse.deserializeBinary(buffer);
+                            resp = proto.ReportResponse.deserializeBinary(buffer).toObject();
                         } catch (exception) {
                             err = exception;
                         }
                     }
-                    return done(err, resp.toObject());
+                    return done(err, resp);
                 });
             });
             req.on('socket', (socket, head) => {


### PR DESCRIPTION
Only happens in node, essentially a 400 would be returned so resp would stay null, but toObject would be called on that anyway. 