### PR TITLE
updated thrift version to 0.12.0, removes security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "google-protobuf": "3.6.1",
     "hex2dec": "1.0.1",
     "source-map-support": "0.3.3",
-    "thrift": "0.11.0"
+    "thrift": "0.12.0"
   },
   "devDependencies": {
     "babel-cli": "6.14.0",


### PR DESCRIPTION

See CVE: https://nvd.nist.gov/vuln/detail/CVE-2018-11798

This removes security warnings for end users. 

Tests pass with changes