### PR TITLE
add browser.d.ts

### DIFF
--- a/browser.d.ts
+++ b/browser.d.ts
@@ -1,0 +1,7 @@
+// When lightstep-tracer/browser is imported, typescript does not
+// automatically infer that the types should be the same as lightstep-tracer. This
+// declaration tells the compiler to look at the same types as index.d.ts.
+declare module "lightstep-tracer/browser" {
+  import m = require("lightstep-tracer");
+  export = m;
+}


### PR DESCRIPTION
Fix an issue where lightstep-tracer/browser does not have types:
<img width="872" alt="Screen Shot 2019-11-13 at 12 00 47 PM" src="https://user-images.githubusercontent.com/2320890/68799579-43335300-060d-11ea-85f1-d381888af822.png">


To work around this, I've added this same declaration in our own `declare.d.ts` for now.