### PR TITLE
Handle protobuf response in tracer

### DIFF
--- a/src/imp/tracer_imp.js
+++ b/src/imp/tracer_imp.js
@@ -1123,10 +1123,18 @@ export default class Tracer extends opentracing.Tracer {
                 // Update the clock state if there's info from the report
                 if (res) {
                     if (res.timing && res.timing.receive_micros && res.timing.transmit_micros) {
+                        // Handle thrift transport timing response.
                         this._clockState.addSample(
                             originMicros,
                             res.timing.receive_micros,
                             res.timing.transmit_micros,
+                            destinationMicros);
+                    } else if (res.receiveTimestamp && res.transmitTimestamp) {
+                        // Handle protobuf transport timing response.
+                        this._clockState.addSample(
+                            originMicros,
+                            res.receiveTimestamp.seconds * 1e6 + res.receiveTimestamp.nanos / 1e3,
+                            res.transmitTimestamp.seconds * 1e6 + res.transmitTimestamp.nanos / 1e3,
                             destinationMicros);
                     } else {
                         // The response does not have timing information. Disable
@@ -1136,10 +1144,15 @@ export default class Tracer extends opentracing.Tracer {
                     }
 
                     if (res.errors && res.errors.length > 0) {
+                        // Handle thrift errors.
                         this._warn('Errors in report', res.errors);
+                    } else if (res.errorsList && res.errorsList.length > 0) {
+                        // Handle protobuf errors.
+                        this._warn('Errors in report', res.errorsList);
                     }
 
                     if (res.commandsList && res.commandsList.length > 0) {
+                        // Handle both thrift and protobuf commands response.
                         if (res.commandsList[0].devMode && this.options().disable_meta_event_reporting !== true) {
                             this.options().meta_event_reporting = true;
                         }


### PR DESCRIPTION
The previous code would only handle the thrift-based response format. This change adds handling for the proto response for both timing and errors.