### PR TITLE
Attempt to fix `make publish`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,6 @@ publish: test test-all coverage
 	echo "Current git branch does not appear to be 'master'. Refusing to publish."; exit 1; \
 	fi
 	npm version $(RELEASE_TYPE)
-	make build # need to rebuild with the new version number
 	git push
 	git push --tags
 	npm whoami

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "node": ">=0.12.0"
   },
   "scripts": {
-    "test": "rm -f test/results/*.json && node node_modules/mocha/bin/mocha -c test/unittest_node.js"
+    "test": "rm -f test/results/*.json && node node_modules/mocha/bin/mocha -c test/unittest_node.js",
+    "version": "make build && git add -A dist"
   },
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Historically, `make publish` has left lingering changes to `/dist` that
are (currently...) necessary for browser usage but don't make it into
the correct build.

Moving the `make build` step into the npm-controlled `version` step and
then adding the `/dist` changes should (hopefully!) fix this.

See https://docs.npmjs.com/cli/version.html for more information.