### PR TITLE
Fix timestamp conversion for protobuf transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## vNext
 
+* Fix timestamp conversion for protobuf transport
+
 ## 0.25.1
 * No changes (minor bump to align with 0.25.1-no-protobuf release)
 

--- a/src/imp/log_record_imp.js
+++ b/src/imp/log_record_imp.js
@@ -93,9 +93,8 @@ export default class LogRecordImp {
         this._clearOverLimits();
         let log = new proto.Log();
         let ts = new googleProtobufTimestampPB.Timestamp();
-        let millis = Math.floor(this._timestampMicros / 1000);
-        let secs = Math.floor(millis / 1000);
-        let nanos = (millis % 1000) * 1000000;
+        let secs = Math.floor(this._timestampMicros / 1000000);
+        let nanos = (this._timestampMicros % 1000000) * 1000;
         ts.setSeconds(secs);
         ts.setNanos(nanos);
         log.setTimestamp(ts);

--- a/src/imp/span_imp.js
+++ b/src/imp/span_imp.js
@@ -230,9 +230,8 @@ export default class SpanImp extends opentracing.Span {
         spanProto.setOperationName(this._operationName);
 
         let startTimestamp = new googleProtobufTimestampPB.Timestamp();
-        let startMillis = Math.floor(this._beginMicros / 1000);
-        let startSeconds = Math.floor(startMillis / 1000);
-        let startNanos = (startMillis % 1000) * 1000000;
+        let startSeconds = Math.floor(this._beginMicros / 1000000);
+        let startNanos = (this._beginMicros % 1000000) * 1000;
         startTimestamp.setSeconds(startSeconds);
         startTimestamp.setNanos(startNanos);
         spanProto.setStartTimestamp(startTimestamp);


### PR DESCRIPTION
Previously, we converted microseconds -> milliseconds -> seconds +
nanoseconds. By converting first to milliseconds, we lost some
granularity at the sub-millisecond level.