### PR TITLE
Fix missing clock offsets over proto transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## vNext
 
+* Fix missing clock offsets over proto transport
 * Fix timestamp conversion for protobuf transport
 
 ## 0.25.1

--- a/src/imp/report_imp.js
+++ b/src/imp/report_imp.js
@@ -82,7 +82,7 @@ export default class ReportImp {
         reportProto.setAuth(auth.toProto());
         reportProto.setReporter(this._runtime.toProto());
         reportProto.setSpansList(spansList);
-        reportProto.setTimestampOffsetMicros(this._timestampOffsetMicros);
+        reportProto.setTimestampOffsetMicros(this._timestampOffsetMicros.toString(10));
         reportProto.setInternalMetrics(internalMetrics);
         return reportProto;
     }


### PR DESCRIPTION
It seems that we must stringify our ints before setting them in order
for them to actually get sent 😬 Without this, offsets won't get applied
to spans sent via proto.

To see this in action:
1. Emit spans over protobuf using an earlier version of the JS tracer
2. Open the trace in LightStep
3. Using the network tools, inspect the response body containing the
trace
4. Observe that the JS spans all have `timestamp_offset` == 0
5. Repeat steps 1-3 using the fixed tracer
6. Observe that after the fix, `timestamp_offset` is no longer always 0