### PR TITLE
fix(fetch): PUT/POSTs were failing

### DIFF
--- a/src/plugins/instrument_fetch.js
+++ b/src/plugins/instrument_fetch.js
@@ -153,13 +153,13 @@ class InstrumentFetch {
         let self = this;
         let tracer = this._tracer;
 
-        return function (request, options = {}) {
-            request = new Request(request, options);
+        return function (input, init) {
+            const request = new Request(input, init);
             const opts = tracer.options();
 
             if (!self._shouldTrace(tracer, request.url)) {
                 // eslint-disable-next-line prefer-spread
-                return proxiedFetch.apply(null, arguments);
+                return proxiedFetch(request);
             }
 
             let span = tracer.startSpan('fetch');


### PR DESCRIPTION
Anything with a request body (content-length > 0) was failing when _excluded_ from fetch tracing instrumentation due to using the initial input object instead of the created/normalized `Request`.

Creating a new request from an old request consumes the old request unless explicitly
cloned, which would throw an error when the old, original request was passed to `fetch`!

I also made it slightly more explicit by not aliasing any existing names or relying on `arguments`.