### PR TITLE
Release v0.30.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,13 @@
 
 ## vNext
 
+## 0.30.1
+* Fix misnamed configuration options. `nodejs_inclusion_patterns` was renamed to `nodejs_url_inclusion_patterns` and `nodejs_exclusion_patterns` was renamed to `nodejs_url_exclusion_patterns`. Because of this bug, the inclusion and exclusion patterns were not being recognized by instrumentation.
+
 ## 0.30.0
 
 * Bug fix for eslint for Microsoft Edge (#241)
-* Add options for auto-instrumented urls and tracing headers (#237) 
+* Add options for auto-instrumented urls and tracing headers (#237)
 
 ## 0.29.0
 


### PR DESCRIPTION
Master has changes from https://github.com/lightstep/lightstep-tracer-javascript/pull/242 that we would like to release as v0.30.1 and v0.30.1-no-protobuf. This PR updates the changelog for the release.