### PR TITLE
remove throw in fetch onError handler

### DIFF
--- a/src/plugins/instrument_nodejs.js
+++ b/src/plugins/instrument_nodejs.js
@@ -227,10 +227,6 @@ class InstrumentNodejs {
                 });
                 span.addTags(tags);
 
-                request.on('error', (e) => {
-                    throw e;
-                });
-
                 request.on('response', (res) => {
                     if (res.statusCode >= 500 && res.statusCode <= 599) {
                         span.addTags({ error : true });


### PR DESCRIPTION
Currently we are throwing an exception in the error handler of the request. This exception cannot be caught in a try-catch block which results in node crashing when an invalid fetch request is made. This PR fixes that issues by removing the error handler which was only being used to throw the error.