### PR TITLE
Use native BigInt instead of hex2dec.

### DIFF
--- a/src/imp/runtime_imp.js
+++ b/src/imp/runtime_imp.js
@@ -1,8 +1,8 @@
 import { crouton_thrift } from '../platform_abstraction_layer'; // eslint-disable-line camelcase
 import _each from '../_each'; // eslint-disable-line camelcase
 import * as coerce from './coerce';
+import util from './util/util';
 
-let converter = require('hex2dec');
 let proto = require('./generated_proto/collector_pb');
 const packageObject = require('../../package.json');
 
@@ -58,7 +58,7 @@ export default class RuntimeImp {
         hostname.setKey('lightstep.hostname');
         hostname.setStringValue(this._attributes['lightstep.hostname']);
 
-        let reporterId = converter.hexToDec(this._runtimeGUID);
+        let reporterId = util.hexToDec(this._runtimeGUID);
 
         let tracerTags = [];
         _each(this._attributes, (val, key) => {

--- a/src/imp/span_imp.js
+++ b/src/imp/span_imp.js
@@ -6,7 +6,6 @@ import { crouton_thrift } from '../platform_abstraction_layer'; // eslint-disabl
 import LogRecordImp from './log_record_imp'; // eslint-disable-line camelcase
 import util from './util/util';
 
-let converter = require('hex2dec');
 let googleProtobufTimestampPB = require('google-protobuf/google/protobuf/timestamp_pb');
 let proto = require('./generated_proto/collector_pb');
 
@@ -231,8 +230,8 @@ export default class SpanImp extends opentracing.Span {
     _toProto() {
         let spanContextProto = new proto.SpanContext();
 
-        spanContextProto.setTraceId(converter.hexToDec(this.traceGUID()));
-        spanContextProto.setSpanId(converter.hexToDec(this.guid()));
+        spanContextProto.setTraceId(util.hexToDec(this.traceGUID()));
+        spanContextProto.setSpanId(util.hexToDec(this.guid()));
 
         let spanProto = new proto.Span();
         spanProto.setSpanContext(spanContextProto);
@@ -274,7 +273,7 @@ export default class SpanImp extends opentracing.Span {
             let ref = new proto.Reference();
             ref.setRelationship(proto.Reference.Relationship.CHILD_OF);
             let parentSpanContext = new proto.SpanContext();
-            parentSpanContext.setSpanId(converter.hexToDec(parentSpanGUID));
+            parentSpanContext.setSpanId(util.hexToDec(parentSpanGUID));
             ref.setSpanContext(parentSpanContext);
             spanProto.setReferencesList([ref]);
         }

--- a/src/imp/util/util.js
+++ b/src/imp/util/util.js
@@ -1,3 +1,5 @@
+const converter = require('hex2dec');
+
 class Util {
     // Similar to a regular setTimeout() call, but dereferences the timer so the
     // program execution will not be held up by this timer.
@@ -12,6 +14,16 @@ class Util {
     shouldSendMetaSpan(opts, tags) {
         let shouldSendSpan = opts.meta_event_reporting === true && tags['lightstep.meta_event'] !== true;
         return shouldSendSpan;
+    }
+
+    // Use native BigInt if available. Native BigInt has a significant
+    // performance improvement over hex2dec
+    hexToDec(hexString) {
+        if (typeof BigInt !== 'function') {
+            return converter.hexToDec(hexString);
+        }
+
+        return BigInt(`0x${hexString}`).toString(10);
     }
 }
 

--- a/src/imp/util/util.js
+++ b/src/imp/util/util.js
@@ -19,11 +19,12 @@ class Util {
     // Use native BigInt if available. Native BigInt has a significant
     // performance improvement over hex2dec
     hexToDec(hexString) {
-        if (typeof BigInt !== 'function') {
+        if (typeof global.BigInt !== 'function') {
             return converter.hexToDec(hexString);
         }
 
-        return BigInt(`0x${hexString}`).toString(10);
+        // eslint-ignore-line
+        return global.BigInt(`0x${hexString}`).toString(10);
     }
 }
 


### PR DESCRIPTION
There are some performance issues associated with usgin hex2dec to manage
big numbers, this PR uses hex2dec if native implementation is not available,
otherwise it goes with BigInt approach which has shown to have a better
performance.

------


<img width="1211" alt="Screenshot 2021-03-12 at 10 40 13" src="https://user-images.githubusercontent.com/6210011/110983643-c8855f80-8348-11eb-9d63-e0a317d548e9.png">
