### PR TITLE
add missing OpenTracing spancontext  methods

### DIFF
--- a/src/imp/span_context_imp.js
+++ b/src/imp/span_context_imp.js
@@ -13,6 +13,14 @@ export default class SpanContextImp {
         return this._baggage[key];
     }
 
+    toTraceId(){
+        return this._traceGUID;
+    }
+
+    toSpanId(){
+        return this._guid
+    }
+
     // ---------------------------------------------------------------------- //
     // LightStep Extensions
     // ---------------------------------------------------------------------- //

--- a/test/suites/common/span_context.js
+++ b/test/suites/common/span_context.js
@@ -18,4 +18,24 @@ describe("SpanContext", function() {
             expect(spanContext.getBaggageItem).to.be.a("function");
         });
     });
+
+    describe("SpanContext#toTraceId", function() {
+        it('is a method', function() {
+            var span = Tracer.startSpan('test');
+            var spanContext = span.context();
+            span.finish();
+
+            expect(spanContext.toSpanId).to.be.a("function");
+        });
+    });
+
+    describe("SpanContext#toSpanId", function() {
+        it('is a method', function() {
+            var span = Tracer.startSpan('test');
+            var spanContext = span.context();
+            span.finish();
+
+            expect(spanContext.toTraceId).to.be.a("function");
+        });
+    });
 });


### PR DESCRIPTION
Heya,

This pr is to add the missing span context methods to the span context implementation. The lightstep tracer extends the openTracing type, which expects the spanContext to have the two methods `toSpanId` and `toTraceId`. It seems like the spanContext already had the info, but didn't expose it through the expected methods.  

Ref:

The openTracing span context spec:
https://github.com/opentracing/opentracing-javascript/blob/fb897fa9d5fd18eb0bbcff9286d4daa476b6e4f7/src/span_context.ts#L11-L32