### PR TITLE
Skip span recording if not marked as sampled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 *Log of significant changes, especially those affecting the supported API.*
 
 ## vNext
+* Omit non-sampled spans from report (#290)
 
 ## 0.33.0
 * Upgrade async (#288)

--- a/src/imp/span_imp.js
+++ b/src/imp/span_imp.js
@@ -133,6 +133,10 @@ export default class SpanImp extends opentracing.Span {
         return this;
     }
 
+    isSampled() {
+        return this._ctx._sampled;
+    }
+
     /**
      * Returns a URL to the trace containing this span.
      *
@@ -194,7 +198,10 @@ export default class SpanImp extends opentracing.Span {
             }).finish();
         }
 
-        this._tracerImp._addSpanRecord(this);
+        // Only record span if sampled
+        if (this.isSampled()) {
+            this._tracerImp._addSpanRecord(this);
+        }
     }
 
     _toThrift() {


### PR DESCRIPTION
Fixes #290 

Prevents non-sampled spans from being recorded and shipped to Lightstep collectors.

Currently this library understands the ot-tracer-sampled header and will set a bit on the SpanContext appropriately, and even propagate this bit to child spans. However, this information is not used in any way. It is not used to trim spans from the report prior to sending to the collectors, nor is it serialized into the report for the collectors to use.